### PR TITLE
Skip boost static libs on Fedora

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,16 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release")
 endif()
 
-set(Boost_USE_STATIC_LIBS ON)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    file(READ "/etc/os-release" OS_RELEASE_CONTENT)
+    # Skip static libs on Fedora - https://github.com/NVIDIA/nvbandwidth/issues/4
+    if(NOT OS_RELEASE_CONTENT MATCHES "ID=.*fedora")
+        set(Boost_USE_STATIC_LIBS ON)
+    endif()
+else()
+    set(Boost_USE_STATIC_LIBS ON)
+endif()
 find_package(Boost COMPONENTS program_options REQUIRED)
 
 set(src

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ The script also builds the nvbandwidth project.
 sudo ./debian_install.sh
 ```
 
+Fedora users can run the following to install:
+```
+sudo dnf -y install boost-devel
+```
+
 ## Build
 To build the `nvbandwidth` executable:
 ```


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/nvbandwidth/issues/4 Add instructions for Fedora in README