### PR TITLE
nvbandwidth 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+## Changelog
+
+### nvbandwidth 0.4
+* Fixed build error caused by static linkage of boost-program-options on fedora
+* Introduced changes to verify data integrity after copy operations
+* Deprecated --loopCount 
+* Fix bugs in one of the copy kernels
+* Fixed timeout conversion calculation
+* Introduced new flags --testSamples to specify benchmark iterations, --useMean to use mean instead of median when reporting results
+* Updated README
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,15 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release")
 endif()
 
-set(Boost_USE_STATIC_LIBS ON)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    file(READ "/etc/os-release" OS_RELEASE_CONTENT)
+    # Skip static libs on Fedora - https://github.com/NVIDIA/nvbandwidth/issues/4
+    if(NOT OS_RELEASE_CONTENT MATCHES "ID=.*fedora")
+        set(Boost_USE_STATIC_LIBS ON)
+    endif()
+else()
+    set(Boost_USE_STATIC_LIBS ON)
+endif()
 find_package(Boost COMPONENTS program_options REQUIRED)
 
 set(src

--- a/common.h
+++ b/common.h
@@ -34,6 +34,7 @@
 #include <unordered_set>
 #include <limits.h>
 #include <optional>
+#include <cstring>
 
 // Default constants
 const unsigned long long defaultLoopCount = 16;
@@ -45,6 +46,8 @@ const unsigned int numThreadPerBlock = 512;
 extern int deviceCount;
 extern unsigned int averageLoopCount;
 extern bool disableAffinity;
+extern bool skipVerification;
+extern bool useMean;
 // Verbosity
 extern bool verbose;
 class Verbosity {
@@ -130,15 +133,15 @@ public:
     
     size_t count(void) const { return values.size(); }
     
-    double average(void) const { 
+    double mean(void) const { 
         return sum() / count();
     }
     
     double variance(void) const {
-        double mean = average();
+        double calculated_mean = mean();
         double sum_diff_squared = 0.0;
         for (double val : values) {
-            double diff = val - mean;
+            double diff = val - calculated_mean;
             sum_diff_squared += diff * diff;
         }
         return (values.size() > 1 ? sum_diff_squared / (values.size() - 1) : 0.0);
@@ -160,6 +163,14 @@ public:
             return (values[idx] + values[idx - 1]) / 2.0;
         } else {
             return values[values.size() / 2];
+        }
+    }
+
+    double returnAppropriateMetric(void) const {
+        if (useMean) {
+            return mean();
+        } else {
+            return median();
         }
     }
 };

--- a/kernels.cuh
+++ b/kernels.cuh
@@ -21,10 +21,10 @@
 #include <cuda.h>
 #include "common.h"
 
-const unsigned long long DEFAULT_SPIN_KERNEL_TIMEOUT = 10000000000ULL;   // 10 seconds
+const unsigned long long DEFAULT_SPIN_KERNEL_TIMEOUT_MS = 10000ULL;   // 10 seconds
 
 size_t copyKernel(CUdeviceptr dstBuffer, CUdeviceptr srcBuffer, size_t size, CUstream stream, unsigned long long loopCount);
-CUresult spinKernel(volatile int *latch, CUstream stream, unsigned long long timeoutNs = DEFAULT_SPIN_KERNEL_TIMEOUT);
+CUresult spinKernel(volatile int *latch, CUstream stream, unsigned long long timeoutMs = DEFAULT_SPIN_KERNEL_TIMEOUT_MS);
 void preloadKernels(int deviceCount);
 
 #endif //NVBANDWIDTH__KERNELS_CUH

--- a/nvbandwidth.cpp
+++ b/nvbandwidth.cpp
@@ -33,6 +33,8 @@ unsigned long long bufferSize;
 unsigned long long loopCount;
 bool verbose;
 bool disableAffinity;
+bool skipVerification;
+bool useMean;
 Verbosity VERBOSE;
 
 // Define testcases here
@@ -112,8 +114,6 @@ void runTestcase(std::vector<Testcase*> &testcases, const std::string &testcaseI
 }
 
 int main(int argc, char **argv) {
-    averageLoopCount = defaultAverageLoopCount;
-
     std::cout << "nvbandwidth Version: " << NVBANDWIDTH_VERSION << std::endl;
     std::cout << "Built from Git version: " << GIT_VERSION << std::endl << std::endl;
     
@@ -121,19 +121,26 @@ int main(int argc, char **argv) {
     std::vector<std::string> testcasesToRun;
 
     // Args parsing
-    opt::options_description desc("nvbandwidth CLI");
-    desc.add_options()
+    opt::options_description visible_opts("nvbandwidth CLI");
+    visible_opts.add_options()
         ("help,h", "Produce help message")
-        ("bufferSize", opt::value<unsigned long long int>(&bufferSize)->default_value(defaultBufferSize), "Memcpy buffer size in MiB")
-        ("loopCount", opt::value<unsigned long long int>(&loopCount)->default_value(defaultLoopCount), "Iterations of memcpy to be performed")
+        ("bufferSize,b", opt::value<unsigned long long int>(&bufferSize)->default_value(defaultBufferSize), "Memcpy buffer size in MiB")
         ("list,l", "List available testcases")
         ("testcase,t", opt::value<std::vector<std::string>>(&testcasesToRun)->multitoken(), "Testcase(s) to run (by name or index)")
         ("verbose,v", opt::bool_switch(&verbose)->default_value(false), "Verbose output")
-        ("disableAffinity,d", opt::bool_switch(&disableAffinity)->default_value(false), "Disable automatic CPU affinity control");
+        ("skipVerification,s", opt::bool_switch(&skipVerification)->default_value(false), "Skips data verification after copy")
+        ("disableAffinity,d", opt::bool_switch(&disableAffinity)->default_value(false), "Disable automatic CPU affinity control")
+        ("testSamples,i", opt::value<unsigned int>(&averageLoopCount)->default_value(defaultAverageLoopCount), "Iterations of the benchmark")
+        ("useMean,m", opt::bool_switch(&useMean)->default_value(false), "Use mean instead of median for results");
+
+    opt::options_description all_opts("");
+    all_opts.add(visible_opts);
+    all_opts.add_options()
+        ("loopCount", opt::value<unsigned long long int>(&loopCount)->default_value(defaultLoopCount), "Iterations of memcpy to be performed within a test sample");
 
     opt::variables_map vm;
     try {
-        opt::store(opt::parse_command_line(argc, argv, desc), vm);
+        opt::store(opt::parse_command_line(argc, argv, all_opts), vm);
         opt::notify(vm);
     } catch (...) {
         std::cout << "ERROR: Invalid Arguments " << std::endl;
@@ -141,13 +148,13 @@ int main(int argc, char **argv) {
             std::cout << argv[i] << " ";
         }
         std::cout << std::endl << std::endl;
-        std::cout << desc << "\n";
+        std::cout << visible_opts << "\n";
         return 1;
     }
 
     if (vm.count("help")) {
-        std::cout << desc << "\n";
-        return 1;
+        std::cout << visible_opts << "\n";
+        return 0;
     }
 
     if (vm.count("list")) {


### PR DESCRIPTION
This version of nvbandwidth has the following changes
- Fixed build error caused by static linkage of boost-program-options on fedora
- Introduced changes to verify data integrity after copy operations
- Deprecated --loopCount
- Fixed bugs in one of the copy kernels
- Fixed timeout conversion calculation
- Introduced new flags --testSamples to specify benchmark iterations, --useMean to use mean instead of median when reporting results
- Updated README