### PR TITLE
Add install phase to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,3 +49,5 @@ endif()
 add_executable(nvbandwidth ${src})
 target_include_directories(nvbandwidth PRIVATE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES} .)
 target_link_libraries(nvbandwidth Boost::program_options ${NVML_LIB_NAME} cuda)
+
+install(nvbandwidth)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,4 +50,4 @@ add_executable(nvbandwidth ${src})
 target_include_directories(nvbandwidth PRIVATE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES} .)
 target_link_libraries(nvbandwidth Boost::program_options ${NVML_LIB_NAME} cuda)
 
-install(nvbandwidth)
+install(TARGETS nvbandwidth)


### PR DESCRIPTION
This is a pretty trivial change, but it allows Spack to handle a standard package installer for nvbandwidth