### PR TITLE
V0.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,14 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CUDA_STANDARD 17)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 
-set(supported_archs "52" "70" "75" "80" "86" "89" "90")
+set(supported_archs "52" "70" "75" "80" "86" "89" "90" "100")
 
-message(STATUS "Detecting underlying CUDA Arch to set CMAKE_CUDA_ARCHITECTURES")
-include(detect_cuda_arch.cmake)
-# Set CMAKE_CUDA_ARCHITECURES based on the underlying device
-cuda_detect_architectures(supported_archs CMAKE_CUDA_ARCHITECTURES)
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    message(STATUS "Detecting underlying CUDA Arch to set CMAKE_CUDA_ARCHITECTURES")
+    include(detect_cuda_arch.cmake)
+    # Set CMAKE_CUDA_ARCHITECURES based on the underlying device
+    cuda_detect_architectures(supported_archs CMAKE_CUDA_ARCHITECTURES)
+endif()
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release")
@@ -37,6 +39,8 @@ set(src
     kernels.cu
     memcpy.cpp
     nvbandwidth.cpp
+    multinode_memcpy.cpp
+    multinode_testcases.cpp
     output.cpp
     json_output.cpp
     json/jsoncpp.cpp
@@ -60,3 +64,9 @@ add_executable(nvbandwidth ${src})
 target_include_directories(nvbandwidth PRIVATE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES} .)
 target_link_libraries(nvbandwidth Boost::program_options ${NVML_LIB_NAME} cuda)
 
+if (MULTINODE)
+    find_package(MPI REQUIRED)
+    include_directories(SYSTEM ${MPI_INCLUDE_PATH})
+    target_link_libraries(nvbandwidth MPI::MPI_CXX)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMULTINODE")
+endif()

--- a/error_handling.h
+++ b/error_handling.h
@@ -15,21 +15,35 @@
  * limitations under the license.
  */
 
-#ifndef ERROR_HANDLING_H
-#define ERROR_HANDLING_H
+#ifndef ERROR_HANDLING_H_
+#define ERROR_HANDLING_H_
 
 void RecordError(const std::stringstream &errmsg);
+
+#ifdef MULTINODE
+#define HOST_INFO " on " << localHostname << ", rank = " << worldRank
+#else
+#define HOST_INFO ""
+#endif
+
+#ifdef MULTINODE
+#include <mpi.h>
+#define MPI_ABORT MPI_Abort(MPI_COMM_WORLD, 1)
+#else
+#define MPI_ABORT
+#endif
 
 // CUDA Error handling
 #define CUDA_ASSERT(x) do { \
     cudaError_t cudaErr = (x); \
     if ((cudaErr) != cudaSuccess) { \
         std::stringstream errmsg; \
-        errmsg << "[" << cudaGetErrorName(cudaErr) << "] " << cudaGetErrorString(cudaErr) << " in expression " << #x << " in " << __PRETTY_FUNCTION__ << "() : " << __FILE__ << ":" <<  __LINE__ << std::endl; \
+        errmsg << "[" << cudaGetErrorName(cudaErr) << "] " << cudaGetErrorString(cudaErr) << " in expression " << #x << HOST_INFO << " in " << __PRETTY_FUNCTION__ << "() : " << __FILE__ << ":" <<  __LINE__ << std::endl; \
         RecordError(errmsg); \
+        MPI_ABORT; \
         std::exit(1); \
     }  \
-} while(0)
+} while ( 0 )
 
 #define CU_ASSERT(x) do { \
     CUresult cuResult = (x); \
@@ -38,31 +52,34 @@ void RecordError(const std::stringstream &errmsg);
         cuGetErrorString(cuResult, &errDescStr); \
         cuGetErrorName(cuResult, &errNameStr); \
         std::stringstream errmsg; \
-        errmsg << "[" << errNameStr << "] " << errDescStr << " in expression " << #x << " in " << __PRETTY_FUNCTION__ << "() : " << __FILE__ << ":" <<  __LINE__ << std::endl; \
+        errmsg << "[" << errNameStr << "] " << errDescStr << " in expression " << #x << HOST_INFO << " in " << __PRETTY_FUNCTION__ << "() : " << __FILE__ << ":" <<  __LINE__ << std::endl; \
         RecordError(errmsg); \
+        MPI_ABORT; \
         std::exit(1); \
     }  \
-} while(0)
+} while ( 0 )
 
 // NVML Error handling
 #define NVML_ASSERT(x) do { \
     nvmlReturn_t nvmlResult = (x); \
     if ((nvmlResult) != NVML_SUCCESS) { \
         std::stringstream errmsg; \
-        errmsg << "NVML_ERROR: [" << nvmlErrorString(nvmlResult) << "] in expression " << #x << " in " << __PRETTY_FUNCTION__ << "() : " << __FILE__ << ":" <<  __LINE__ << std::endl; \
+        errmsg << "NVML_ERROR: [" << nvmlErrorString(nvmlResult) << "] in expression " << #x << HOST_INFO << " in " << __PRETTY_FUNCTION__ << "() : " << __FILE__ << ":" <<  __LINE__ << std::endl; \
         RecordError(errmsg); \
+        MPI_ABORT; \
         std::exit(1); \
     }  \
-} while(0)
+} while ( 0 )
 
 // Generic Error handling
 #define ASSERT(x) do { \
     if (!(x)) { \
         std::stringstream errmsg; \
-        errmsg << "ASSERT in expression " << #x << " in " << __PRETTY_FUNCTION__ << "() : " << __FILE__ << ":" <<  __LINE__  << std::endl; \
+        errmsg << "ASSERT in expression " << #x << HOST_INFO << " in " << __PRETTY_FUNCTION__ << "() : " << __FILE__ << ":" <<  __LINE__  << std::endl; \
         RecordError(errmsg); \
+        MPI_ABORT; \
         std::exit(1); \
     }  \
-} while(0)
+} while ( 0 )
 
-#endif
+#endif  // ERROR_HANDLING_H_

--- a/inline_common.h
+++ b/inline_common.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef INLINE_COMMON_H
-#define INLINE_COMMON_H
+#ifndef INLINE_COMMON_H_
+#define INLINE_COMMON_H_
 
 #include "common.h"
 #include "error_handling.h"
@@ -25,8 +25,12 @@ template <class T> struct PeerValueMatrix {
     std::vector<std::optional <T>> m_matrix;
     int m_rows, m_columns;
     std::string key;
+    std::vector<std::string> column_labels;
+    std::vector<std::string> row_labels;
+    bool pFormatter;
+    UnitType uType;
 
-    PeerValueMatrix(int rows, int columns, std::string key = ""): m_matrix(rows * columns), m_rows(rows), m_columns(columns), key(key) {}
+    PeerValueMatrix(int rows, int columns, std::string key = "", bool pFormatter = perfFormatter, UnitType uType = BANDWIDTH): m_matrix(rows * columns), m_rows(rows), m_columns(columns), key(key), pFormatter(perfFormatter), uType(uType) {}
 
     std::optional <T> &value(int src, int dst) {
         ASSERT(src >= 0 && src < m_rows);
@@ -38,6 +42,14 @@ template <class T> struct PeerValueMatrix {
         ASSERT(dst >= 0 && dst < m_columns);
         return m_matrix[src * m_columns + dst];
     }
+
+    void setRowLabels(std::vector<std::string> _row_labels) {
+        row_labels = _row_labels;
+    }
+
+    void setColumnLabels(std::vector<std::string> _column_labels) {
+        column_labels = _column_labels;
+    }
 };
 
 template <class T>
@@ -48,19 +60,37 @@ std::ostream &operator<<(std::ostream &o, const PeerValueMatrix<T> &matrix) {
     T sum = 0;
     int count = 0;
 
-    o << "  ";
+    // First square of the table should be blank, calculate and print appropriately many spaces
+    int columnIdWidth = 2;
+    for (auto s : matrix.row_labels) {
+        columnIdWidth = std::max(columnIdWidth, (int) s.size());
+    }
+
+    for (int i = 0; i < columnIdWidth; i++) {
+        o << " ";
+    }
+
     for (int currentDevice = 0; currentDevice < matrix.m_columns; currentDevice++) {
-        o << std::setw(10) << currentDevice;
+        if (matrix.column_labels.size() > 0) {
+            o << std::setw(10) << matrix.column_labels[currentDevice];
+        } else {
+            o << std::setw(10) << currentDevice;
+        }
     }
     o << std::endl;
+
     for (int currentDevice = 0; currentDevice < matrix.m_rows; currentDevice++) {
-        o << std::setw(2) << currentDevice;
+        if (matrix.row_labels.size() > 0) {
+            o << std::setw(columnIdWidth) << matrix.row_labels[currentDevice];
+        } else {
+            o << std::setw(2) << currentDevice;
+        }
+
         for (int peer = 0; peer < matrix.m_columns; peer++) {
             std::optional <T> val = matrix.value(currentDevice, peer);
             if (val) {
                 o << std::setw(10) << val.value();
-            }
-            else {
+            } else {
                 o << std::setw(10) << "N/A";
             }
             sum += val.value_or(0.0);
@@ -71,7 +101,11 @@ std::ostream &operator<<(std::ostream &o, const PeerValueMatrix<T> &matrix) {
         o << std::endl;
     }
     o << std::endl;
-    o << "SUM " << matrix.key << " " << sum << std::endl;
+    if (matrix.pFormatter) {
+        o << "&&&& PERF " << matrix.key << " " << sum << getUnitString(matrix.uType) << std::endl;
+    } else {
+        o << "SUM " << matrix.key << " " << sum << std::endl;
+    }
 
     VERBOSE << "MIN " << matrix.key << " " << minVal << '\n';
     VERBOSE << "MAX " << matrix.key << " " << maxVal << '\n';
@@ -123,4 +157,4 @@ inline bool isMemoryOwnedByCUDA(void *memory) {
     }
 }
 
-#endif
+#endif  // INLINE_COMMON_H_

--- a/json_output.cpp
+++ b/json_output.cpp
@@ -48,6 +48,10 @@ const std::string NVB_WAIVED("Waived");
 const std::string NVB_NOT_FOUND("Not Found");
 const std::string NVB_ERROR_STATUS("Error");
 
+JsonOutput::JsonOutput(bool _shouldOutput) {
+    shouldOutput = _shouldOutput;
+}
+
 void JsonOutput::addTestcaseResults(const PeerValueMatrix<double> &matrix, const std::string &description) {
     assert(m_root[NVB_TITLE][NVB_TESTCASES].isArray() && m_root[NVB_TITLE][NVB_TESTCASES].size() > 0);
 
@@ -67,8 +71,7 @@ void JsonOutput::addTestcaseResults(const PeerValueMatrix<double> &matrix, const
                 std::stringstream buf;
                 buf << val.value();
                 row.append(buf.str());
-            }
-            else {
+            } else {
                 row.append("N/A");
             }
             sum += val.value_or(0.0);
@@ -167,7 +170,9 @@ void JsonOutput::addCudaAndDriverInfo(int cudaVersion, const std::string &driver
 }
 
 void JsonOutput::print() {
-    std::cout << m_root.toStyledString() << std::endl;
+    if (shouldOutput) {
+        std::cout << m_root.toStyledString() << std::endl;
+    }
 }
 
 void JsonOutput::printInfo() {

--- a/json_output.h
+++ b/json_output.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef JSON_OUTPUT_H
-#define JSON_OUTPUT_H
+#ifndef JSON_OUTPUT_H_
+#define JSON_OUTPUT_H_
 
 #include <json/json.h>
 #include <string>
@@ -24,9 +24,10 @@
 #include "common.h"
 #include "output.h"
 
-class JsonOutput : public Output
-{
-public:
+class JsonOutput : public Output {
+ public:
+    JsonOutput(bool shouldOutput);
+
     void addTestcase(const std::string &name, const std::string &status, const std::string &msg = "");
 
     void setTestcaseStatusAndAddIfNeeded(const std::string &name, const std::string &status, const std::string &msg = "");
@@ -34,7 +35,7 @@ public:
     void print();
 
     void recordError(const std::string &error);
-    
+
     void recordError(const std::vector<std::string> &errorParts);
 
     void recordErrorCurrentTest(const std::string &errorPart1, const std::string &errorPart2);
@@ -49,8 +50,9 @@ public:
 
     void printInfo();
 
-private:
+ private:
+    bool shouldOutput;
     Json::Value m_root;
 };
 
-#endif
+#endif  // JSON_OUTPUT_H_

--- a/kernels.cu
+++ b/kernels.cu
@@ -26,6 +26,7 @@ __global__ void simpleCopyKernel(unsigned long long loopCount, uint4 *dst, uint4
         __stcg(dst_uint4, __ldcg(src_uint4));
     }
 }
+
 __global__ void stridingMemcpyKernel(unsigned int totalThreadCount, unsigned long long loopCount, uint4* dst, uint4* src, size_t chunkSizeInElement) {
     unsigned long long from = blockDim.x * blockIdx.x + threadIdx.x;
     unsigned long long bigChunkSizeInElement = chunkSizeInElement / 12;
@@ -71,15 +72,36 @@ __global__ void stridingMemcpyKernel(unsigned int totalThreadCount, unsigned lon
         }
     }
 }
-__global__ void ptrChasingKernel(struct LatencyNode *data, size_t size, unsigned int accesses, unsigned long long* time) {
+
+// This kernel performs a split warp copy, alternating copy directions across warps.
+__global__ void splitWarpCopyKernel(unsigned long long loopCount, uint4 *dst, uint4 *src) {
+    for (unsigned int i = 0; i < loopCount; i++) {
+        unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+        unsigned int globalWarpId = idx / warpSize;
+        unsigned int warpLaneId = idx % warpSize;
+        uint4* dst_uint4;
+        uint4* src_uint4;
+
+        // alternate copy directions across warps
+        if (globalWarpId & 0x1) {
+            // odd warp
+            dst_uint4 = dst + (globalWarpId * warpSize + warpLaneId);
+            src_uint4 = src + (globalWarpId * warpSize + warpLaneId);
+        } else {
+            // even warp
+            dst_uint4 = src + (globalWarpId * warpSize + warpLaneId);
+            src_uint4 = dst + (globalWarpId * warpSize + warpLaneId);
+        }
+
+        __stcg(dst_uint4, __ldcg(src_uint4));
+    }
+}
+
+__global__ void ptrChasingKernel(struct LatencyNode *data, size_t size, unsigned int accesses) {
     struct LatencyNode *p = data;
-    auto start = clock64();
     for (auto i = 0; i < accesses; ++i) {
         p = p->next;
     }
-
-    auto interval = static_cast<unsigned long long>(clock64() - start);
-    atomicAdd(time, interval);
 
     // avoid compiler optimization
     if (p == nullptr) {
@@ -87,36 +109,81 @@ __global__ void ptrChasingKernel(struct LatencyNode *data, size_t size, unsigned
     }
 }
 
+static __device__ __noinline__
+void mc_st_u32(unsigned int *dst, unsigned int v) {
+#if __CUDA_ARCH__ >= 900
+    asm volatile ("multimem.st.u32 [%0], %1;" :: "l"(dst), "r" (v));
+#endif
+}
+
+static __device__ __noinline__
+void mc_ld_u32(unsigned int *dst, const unsigned int *src) {
+#if __CUDA_ARCH__ >= 900
+     asm volatile ("multimem.ld_reduce.and.b32 %0, [%1];" : "=r"((*dst)) : "l" (src));
+#endif
+}
+
+// Writes from regular memory to multicast memory
+__global__ void multicastCopyKernel(unsigned long long loopCount, unsigned int* __restrict__ dst, unsigned int* __restrict__ src, size_t nElems) {
+    const size_t totalThreadCount = blockDim.x * gridDim.x;
+    const size_t offset = blockDim.x * blockIdx.x + threadIdx.x;
+    unsigned int* const enddst = dst + nElems;
+    dst += offset;
+    src += offset;
+
+    for (unsigned int i = 0; i < loopCount; i++) {
+        // Reset pointers to src and dst chunks.
+        unsigned int* cur_src_ptr = src;
+        unsigned int* cur_dst_ptr = dst;
+        #pragma unroll(12)
+        while (cur_dst_ptr < enddst) {
+            mc_st_u32(cur_dst_ptr, *cur_src_ptr);
+            cur_dst_ptr += totalThreadCount;
+            cur_src_ptr += totalThreadCount;
+        }
+    }
+}
+
 double latencyPtrChaseKernel(const int srcId, void* data, size_t size, unsigned long long loopCount) {
-    unsigned long long *hTime;
     CUstream stream;
     int device, clock_rate_khz;
     double latencySum = 0.0f, finalLatencyPerAccessNs = 0.0;
     CUcontext srcCtx;
+    cudaEvent_t start, end;
+    float latencyMs = 0;
+
+    CUDA_ASSERT(cudaEventCreate(&start));
+    CUDA_ASSERT(cudaEventCreate(&end));
+
     CU_ASSERT(cuDevicePrimaryCtxRetain(&srcCtx, srcId));
     CU_ASSERT(cuCtxSetCurrent(srcCtx));
-    
+
     CU_ASSERT(cuStreamCreate(&stream, CU_STREAM_DEFAULT));
-    CU_ASSERT(cuMemAllocManaged((CUdeviceptr*) &hTime, sizeof(unsigned long long), CU_MEM_ATTACH_GLOBAL));
     CU_ASSERT(cuCtxGetDevice(&device));
     CU_ASSERT(cuDeviceGetAttribute(&clock_rate_khz, CU_DEVICE_ATTRIBUTE_CLOCK_RATE, device));
 
-    for ( int i = 0; i < loopCount; i++) {
-        memset((void*)hTime, 0, sizeof(unsigned long long));
-        ptrChasingKernel <<< 1, 1, 0, stream>>> ((struct LatencyNode*) data, size, latencyMemAccessCnt, hTime);
+    for ( int i = 0; i < loopCount; i++ ) {
+        CUDA_ASSERT(cudaEventRecord(start, stream));
+        ptrChasingKernel <<< 1, 1, 0, stream>>> ((struct LatencyNode*) data, size, latencyMemAccessCnt);
+        CUDA_ASSERT(cudaEventRecord(end, stream));
         CUDA_ASSERT(cudaGetLastError());
         CU_ASSERT(cuStreamSynchronize(stream));
-        latencySum += static_cast<double>(hTime[0]) / (1.0E3 /* khz -> hz */ * static_cast<double>(clock_rate_khz));
+        cudaEventElapsedTime(&latencyMs, start, end);
+        latencySum += (latencyMs / 1000);
     }
     finalLatencyPerAccessNs = (latencySum * 1.0E9) / (loopCount * latencyMemAccessCnt);
-    return finalLatencyPerAccessNs;
 
+    CUDA_ASSERT(cudaEventDestroy(start));
+    CUDA_ASSERT(cudaEventDestroy(end));
+
+    return finalLatencyPerAccessNs;
 }
-size_t copyKernel(CUdeviceptr dstBuffer, CUdeviceptr srcBuffer, size_t size, CUstream stream, unsigned long long loopCount) {
+
+size_t copyKernel(MemcpyDescriptor &desc) {
     CUdevice dev;
     CUcontext ctx;
 
-    CU_ASSERT(cuStreamGetCtx(stream, &ctx));
+    CU_ASSERT(cuStreamGetCtx(desc.stream, &ctx));
     CU_ASSERT(cuCtxGetDevice(&dev));
 
     int numSm;
@@ -129,18 +196,18 @@ size_t copyKernel(CUdeviceptr dstBuffer, CUdeviceptr srcBuffer, size_t size, CUs
     // Please note that to achieve peak bandwidth, it is suggested to use the
     // default buffer size, which in turn triggers the use of the optimized
     // kernel.
-    if (size < (defaultBufferSize * _MiB) ) {
+    if (desc.copySize < (defaultBufferSize * _MiB)) {
         // copy size is rounded down to 16 bytes
-        int numUint4 = size / sizeof(uint4);
+        unsigned int numUint4 = desc.copySize / sizeof(uint4);
         // we allow max 1024 threads per block, and then scale out the copy across multiple blocks
-        dim3 block(std::min(numUint4, 1024));
+        dim3 block(std::min(numUint4, static_cast<unsigned int>(1024)));
         dim3 grid(numUint4/block.x);
-        simpleCopyKernel <<<grid, block, 0 , stream>>> (loopCount, (uint4 *)dstBuffer, (uint4 *)srcBuffer);
+        simpleCopyKernel <<<grid, block, 0 , desc.stream>>> (desc.loopCount, (uint4 *)desc.dst, (uint4 *)desc.src);
         return numUint4 * sizeof(uint4);
     }
 
     // adjust size to elements (size is multiple of MB, so no truncation here)
-    size_t sizeInElement = size / sizeof(uint4);
+    size_t sizeInElement = desc.copySize / sizeof(uint4);
     // this truncates the copy
     sizeInElement = totalThreadCount * (sizeInElement / totalThreadCount);
 
@@ -148,13 +215,49 @@ size_t copyKernel(CUdeviceptr dstBuffer, CUdeviceptr srcBuffer, size_t size, CUs
 
     dim3 gridDim(numSm, 1, 1);
     dim3 blockDim(numThreadPerBlock, 1, 1);
-    stridingMemcpyKernel<<<gridDim, blockDim, 0, stream>>> (totalThreadCount, loopCount, (uint4 *)dstBuffer, (uint4 *)srcBuffer, chunkSizeInElement);
+    stridingMemcpyKernel<<<gridDim, blockDim, 0, desc.stream>>> (totalThreadCount, desc.loopCount, (uint4 *)desc.dst, (uint4 *)desc.src, chunkSizeInElement);
 
     return sizeInElement * sizeof(uint4);
 }
 
-__global__ void spinKernelDevice(volatile int *latch, const unsigned long long timeoutClocks)
-{
+size_t copyKernelSplitWarp(MemcpyDescriptor &desc) {
+    CUdevice dev;
+    CUcontext ctx;
+
+    CU_ASSERT(cuStreamGetCtx(desc.stream, &ctx));
+    CU_ASSERT(cuCtxGetDevice(&dev));
+
+    int numSm;
+    CU_ASSERT(cuDeviceGetAttribute(&numSm, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, dev));
+
+    // copy size is rounded down to 16 bytes
+    unsigned int numUint4 = desc.copySize / sizeof(uint4);
+
+    // we allow max 1024 threads per block, and then scale out the copy across multiple blocks
+    dim3 block(std::min(numUint4, static_cast<unsigned int>(1024)));
+    dim3 grid(numUint4/block.x);
+    splitWarpCopyKernel <<<grid, block, 0 , desc.stream>>> (desc.loopCount, (uint4 *)desc.dst, (uint4 *)desc.src);
+    return numUint4 * sizeof(uint4);
+}
+
+size_t multicastCopy(CUdeviceptr dstBuffer, CUdeviceptr srcBuffer, size_t size, CUstream stream, unsigned long long loopCount) {
+    CUdevice dev;
+    CUcontext ctx;
+
+    CU_ASSERT(cuStreamGetCtx(stream, &ctx));
+    CU_ASSERT(cuCtxGetDevice(&dev));
+
+    int numSm;
+    CU_ASSERT(cuDeviceGetAttribute(&numSm, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, dev));
+    // adjust size to elements (size is multiple of MB, so no truncation here)
+    size_t sizeInElement = size / sizeof(unsigned);
+    dim3 gridDim(numSm, 1, 1);
+    dim3 blockDim(numThreadPerBlock, 1, 1);
+    multicastCopyKernel<<<gridDim, blockDim, 0, stream>>> (loopCount, (unsigned *)dstBuffer, (unsigned *)srcBuffer, sizeInElement);
+    return sizeInElement * sizeof(unsigned);
+}
+
+__global__ void spinKernelDevice(volatile int *latch, const unsigned long long timeoutClocks) {
     register unsigned long long endTime = clock64() + timeoutClocks;
     while (!*latch) {
         if (timeoutClocks != ~0ULL && clock64() > endTime) {
@@ -163,8 +266,7 @@ __global__ void spinKernelDevice(volatile int *latch, const unsigned long long t
     }
 }
 
-CUresult spinKernel(volatile int *latch, CUstream stream, unsigned long long timeoutMs)
-{
+CUresult spinKernel(volatile int *latch, CUstream stream, unsigned long long timeoutMs) {
     int clocksPerMs = 0;
     CUcontext ctx;
     CUdevice dev;
@@ -181,14 +283,185 @@ CUresult spinKernel(volatile int *latch, CUstream stream, unsigned long long tim
     return CUDA_SUCCESS;
 }
 
-void preloadKernels(int deviceCount)
-{
+__global__ void spinKernelDeviceMultistage(volatile int *latch1, volatile int *latch2, const unsigned long long timeoutClocks) {
+    if (latch1) {
+        register unsigned long long endTime = clock64() + timeoutClocks;
+        while (!*latch1) {
+            if (timeoutClocks != ~0ULL && clock64() > endTime) {
+                return;
+            }
+        }
+
+        *latch2 = 1;
+    }
+
+    register unsigned long long endTime = clock64() + timeoutClocks;
+    while (!*latch2) {
+        if (timeoutClocks != ~0ULL && clock64() > endTime) {
+            break;
+        }
+    }
+}
+
+// Implement a 2-stage spin kernel for multi-node synchronization.
+// One of the host nodes releases the first latch. Subsequently,
+// the second latch is released, that is polled by all other devices
+// latch1 argument is optional. If defined, kernel will spin on it until released, and then will release latch2.
+// latch2 argument is mandatory. Kernel will spin on it until released.
+// timeoutMs argument applies to each stage separately.
+// However, since each kernel will spin on only one stage, total runtime is still limited by timeoutMs
+CUresult spinKernelMultistage(volatile int *latch1, volatile int *latch2, CUstream stream, unsigned long long timeoutMs) {
+    int clocksPerMs = 0;
+    CUcontext ctx;
+    CUdevice dev;
+
+    ASSERT(latch2 != nullptr);
+
+    CU_ASSERT(cuStreamGetCtx(stream, &ctx));
+    CU_ASSERT(cuCtxGetDevice(&dev));
+
+    CU_ASSERT(cuDeviceGetAttribute(&clocksPerMs, CU_DEVICE_ATTRIBUTE_CLOCK_RATE, dev));
+
+    unsigned long long timeoutClocks = clocksPerMs * timeoutMs;
+
+    spinKernelDeviceMultistage<<<1, 1, 0, stream>>>(latch1, latch2, timeoutClocks);
+
+    return CUDA_SUCCESS;
+}
+
+__global__ void memsetKernelDevice(CUdeviceptr buffer, CUdeviceptr pattern, unsigned int num_elements, unsigned int num_pattern_elements) {
+    unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int* buf = reinterpret_cast<unsigned int*>(buffer);
+    unsigned int* pat = reinterpret_cast<unsigned int*>(pattern);
+
+    if (idx < num_elements) {
+        buf[idx] = pat[idx % num_pattern_elements];
+    }
+}
+
+// This kernel clears memory locations in the buffer based on warp parity.
+// If clearOddWarpIndexed is true, it clears buffer locations indexed by odd warps.
+// Otherwise, it clears buffer locations indexed by even warps.
+__global__ void memclearKernelByWarpParityDevice(CUdeviceptr buffer, bool clearOddWarpIndexed) {
+    unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    uint4* buf = reinterpret_cast<uint4*>(buffer);
+    unsigned int globalWarpId = idx / warpSize;
+    unsigned int thread_idx_in_warp = idx % warpSize;
+
+    if (clearOddWarpIndexed) {
+        // clear memory locations in buffer indexed by odd warps
+        if (globalWarpId & 0x1) {
+            buf[globalWarpId * warpSize + thread_idx_in_warp] = make_uint4(0x0, 0x0, 0x0, 0x0);
+        }
+    } else {
+        // clear memory locations in buffer indexed by even warps
+        if (!(globalWarpId & 0x1)) {
+            buf[globalWarpId * warpSize + thread_idx_in_warp] = make_uint4(0x0, 0x0, 0x0, 0x0);
+        }
+    }
+}
+
+__global__ void memcmpKernelDevice(CUdeviceptr buffer, CUdeviceptr pattern, unsigned int num_elements, unsigned int num_pattern_elements, CUdeviceptr errorFlag) {
+    unsigned long long idx = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int* buf = reinterpret_cast<unsigned int*>(buffer);
+    unsigned int* pat = reinterpret_cast<unsigned int*>(pattern);
+
+    if (idx < num_elements) {
+        if (buf[idx] != pat[idx % num_pattern_elements]) {
+            if (atomicCAS((int*)errorFlag, 0, 1) == 0) {
+                // have the first thread that detects a mismatch print the error message
+                printf(" Invalid value when checking the pattern at %p\n", (void*)((char*)buffer));
+                printf(" Current offset : %lu \n", idx);
+                return;
+            }
+        }
+    }
+}
+
+__global__ void multicastMemcmpKernelDevice(CUdeviceptr buffer, CUdeviceptr pattern, unsigned int num_elements, unsigned int num_pattern_elements, CUdeviceptr errorFlag) {
+    unsigned long long idx = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int* buf = reinterpret_cast<unsigned int*>(buffer);
+    unsigned int* pat = reinterpret_cast<unsigned int*>(pattern);
+
+    if (idx < num_elements) {
+        unsigned buf_val;
+        mc_ld_u32(&buf_val, &buf[idx]);
+        if (buf_val != pat[idx % num_pattern_elements]) {
+            if (atomicCAS((int*)errorFlag, 0, 1) == 0) {
+                // have the first thread that detects a mismatch print the error message
+                printf(" Invalid value when checking the pattern at %p\n", (void*)((char*)buffer));
+                printf(" Current offset : %lu \n", idx);
+                return;
+            }
+        }
+    }
+}
+
+CUresult memsetKernel(CUstream stream, CUdeviceptr buffer, CUdeviceptr pattern, unsigned int num_elements, unsigned int num_pattern_elements) {
+    unsigned threadsPerBlock = 1024;
+    unsigned blocks = (num_elements + threadsPerBlock - 1) / threadsPerBlock;
+
+    memsetKernelDevice<<<blocks, threadsPerBlock, 0, stream>>>(buffer, pattern, num_elements, num_pattern_elements);
+    CUDA_ASSERT(cudaGetLastError());
+    return CUDA_SUCCESS;
+}
+
+CUresult memclearKernelByWarpParity(CUstream stream, CUdeviceptr buffer, size_t size, bool clearOddWarpIndexed) {
+    CUdevice dev;
+    CUcontext ctx;
+
+    CU_ASSERT(cuStreamGetCtx(stream, &ctx));
+    CU_ASSERT(cuCtxGetDevice(&dev));
+
+    int numSm;
+    CU_ASSERT(cuDeviceGetAttribute(&numSm, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, dev));
+    // copy size is rounded down to 16 bytes
+    unsigned int numUint4 = size / sizeof(uint4);
+
+    // we allow max 1024 threads per block, and then scale out the copy across multiple blocks
+    dim3 block(std::min(numUint4, static_cast<unsigned int>(1024)));
+
+    dim3 grid(numUint4/block.x);
+    memclearKernelByWarpParityDevice <<<grid, block, 0 , stream>>> (buffer, clearOddWarpIndexed);
+    CUDA_ASSERT(cudaGetLastError());
+    return CUDA_SUCCESS;
+}
+
+CUresult memcmpKernel(CUstream stream, CUdeviceptr buffer, CUdeviceptr pattern, unsigned int num_elements, unsigned int num_pattern_elements, CUdeviceptr errorFlag) {
+    unsigned threadsPerBlock = 1024;
+    unsigned blocks = (num_elements + threadsPerBlock - 1) / threadsPerBlock;
+
+    memcmpKernelDevice<<<blocks, threadsPerBlock, 0, stream>>>(buffer, pattern, num_elements, num_pattern_elements, errorFlag);
+    CUDA_ASSERT(cudaGetLastError());
+    return CUDA_SUCCESS;
+}
+
+CUresult multicastMemcmpKernel(CUstream stream, CUdeviceptr buffer, CUdeviceptr pattern, unsigned int num_elements, unsigned int num_pattern_elements, CUdeviceptr errorFlag) {
+    unsigned threadsPerBlock = 1024;
+    unsigned blocks = (num_elements + threadsPerBlock - 1) / threadsPerBlock;
+
+    multicastMemcmpKernelDevice<<<blocks, threadsPerBlock, 0, stream>>>(buffer, pattern, num_elements, num_pattern_elements, errorFlag);
+    CUDA_ASSERT(cudaGetLastError());
+    return CUDA_SUCCESS;
+}
+
+void preloadKernels(int deviceCount) {
     cudaFuncAttributes unused;
     for (int iDev = 0; iDev < deviceCount; iDev++) {
         cudaSetDevice(iDev);
         cudaFuncGetAttributes(&unused, &stridingMemcpyKernel);
         cudaFuncGetAttributes(&unused, &spinKernelDevice);
+        cudaFuncGetAttributes(&unused, &spinKernelDeviceMultistage);
         cudaFuncGetAttributes(&unused, &simpleCopyKernel);
+        cudaFuncGetAttributes(&unused, &splitWarpCopyKernel);
+        cudaFuncGetAttributes(&unused, &multicastCopyKernel);
+        cudaFuncGetAttributes(&unused, &ptrChasingKernel);
+        cudaFuncGetAttributes(&unused, &multicastCopyKernel);
+        cudaFuncGetAttributes(&unused, &memsetKernelDevice);
+        cudaFuncGetAttributes(&unused, &memcmpKernelDevice);
+        cudaFuncGetAttributes(&unused, &multicastMemcmpKernelDevice);
     }
 }
+
+
 

--- a/kernels.cuh
+++ b/kernels.cuh
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef NVBANDWIDTH__KERNELS_CUH
-#define NVBANDWIDTH__KERNELS_CUH
+#ifndef KERNELS_CUH_
+#define KERNELS_CUH_
 
 #include <cuda.h>
 #include "common.h"
@@ -24,9 +24,16 @@
 
 const unsigned long long DEFAULT_SPIN_KERNEL_TIMEOUT_MS = 10000ULL;   // 10 seconds
 
-size_t copyKernel(CUdeviceptr dstBuffer, CUdeviceptr srcBuffer, size_t size, CUstream stream, unsigned long long loopCount);
+size_t copyKernel(MemcpyDescriptor &desc);
+size_t copyKernelSplitWarp(MemcpyDescriptor &desc);
+size_t multicastCopy(CUdeviceptr dstBuffer, CUdeviceptr srcBuffer, size_t size, CUstream stream, unsigned long long loopCount);
 CUresult spinKernel(volatile int *latch, CUstream stream, unsigned long long timeoutMs = DEFAULT_SPIN_KERNEL_TIMEOUT_MS);
+CUresult spinKernelMultistage(volatile int *latch1, volatile int *latch2, CUstream stream, unsigned long long timeoutMs = DEFAULT_SPIN_KERNEL_TIMEOUT_MS);
 void preloadKernels(int deviceCount);
 double latencyPtrChaseKernel(const int srcId, void* data, size_t size, unsigned long long loopCount);
+CUresult memsetKernel(CUstream stream, CUdeviceptr buffer, CUdeviceptr pattern, unsigned int num_elements, unsigned int num_pattern_elements);
+CUresult memcmpKernel(CUstream stream, CUdeviceptr buffer, CUdeviceptr pattern, unsigned int num_elements, unsigned int num_pattern_elements, CUdeviceptr errorFlag);
+CUresult multicastMemcmpKernel(CUstream stream, CUdeviceptr buffer, CUdeviceptr pattern, unsigned int num_elements, unsigned int num_pattern_elements, CUdeviceptr errorFlag);
 
-#endif //NVBANDWIDTH__KERNELS_CUH
+CUresult memclearKernelByWarpParity(CUstream stream, CUdeviceptr buffer, size_t size, bool clearOddWarpIndexed);
+#endif  // KERNELS_CUH_

--- a/memcpy.cpp
+++ b/memcpy.cpp
@@ -16,14 +16,19 @@
  */
 
 #include "common.h"
+#include <cuda_runtime.h>
+#include <cuda.h>
 #include "inline_common.h"
 #include "memcpy.h"
 #include "output.h"
 #include "kernels.cuh"
 #include "vector_types.h"
-#include "common.h"
-
+#ifdef MULTINODE
+#include <mpi.h>
+#include "multinode_memcpy.h"
+#endif
 #define WARMUP_COUNT 4
+#include <cassert>
 
 MemcpyBuffer::MemcpyBuffer(size_t bufferSize): bufferSize(bufferSize), buffer(nullptr) {}
 
@@ -34,87 +39,8 @@ CUdeviceptr MemcpyBuffer::getBuffer() const {
 size_t MemcpyBuffer::getBufferSize() const {
     return bufferSize;
 }
-void MemcpyBuffer::memsetPattern(CUdeviceptr buffer, unsigned long long size, unsigned int seed) const {
-    unsigned int* pattern;
-    unsigned int n = 0;
-    void * _buffer = (void*) buffer;
-    unsigned long long _2MBchunkCount = size / (1024 * 1024 * 2);
-    unsigned long long remaining = size - (_2MBchunkCount * 1024 * 1024 * 2);
 
-    // Allocate 2MB of pattern
-    CU_ASSERT(cuMemHostAlloc((void**)&pattern, sizeof(char) * 1024 * 1024 * 2, CU_MEMHOSTALLOC_PORTABLE));
-    xorshift2MBPattern(pattern, seed);
-
-    for (n = 0; n < _2MBchunkCount; n++) {
-        CU_ASSERT(cuMemcpyAsync((CUdeviceptr)_buffer, (CUdeviceptr)pattern, 1024 * 1024 * 2, CU_STREAM_PER_THREAD));
-        _buffer = (char*)_buffer + (1024 * 1024 * 2);
-    }
-    if (remaining) {
-        CU_ASSERT(cuMemcpyAsync((CUdeviceptr)_buffer, (CUdeviceptr)pattern, (size_t)remaining, CU_STREAM_PER_THREAD));
-    }
-
-    CU_ASSERT(streamSynchronizeWrapper(CU_STREAM_PER_THREAD));
-    CU_ASSERT(cuMemFreeHost((void*)pattern));
-}
-
-void MemcpyBuffer::memcmpPattern(CUdeviceptr buffer, unsigned long long size, unsigned int seed) const {
-     unsigned int* devicePattern;
-    unsigned int* pattern;
-    unsigned long long _2MBchunkCount = size / (1024 * 1024 * 2);
-    unsigned long long remaining = size - (_2MBchunkCount * 1024 * 1024 * 2);
-    unsigned int n = 0;
-    unsigned int x = 0;
-    void * _buffer = (void*) buffer;
-
-    // Allocate 2MB of pattern
-    CU_ASSERT(cuMemHostAlloc((void**)&devicePattern, sizeof(char) * 1024 * 1024 * 2, CU_MEMHOSTALLOC_PORTABLE));
-    pattern = (unsigned int*)malloc(sizeof(char) * 1024 * 1024 * 2);
-    xorshift2MBPattern(pattern, seed);
-
-    for (n = 0; n < _2MBchunkCount; n++) {
-        CU_ASSERT(cuMemcpyAsync((CUdeviceptr)devicePattern, (CUdeviceptr)_buffer, 1024 * 1024 * 2, CU_STREAM_PER_THREAD));
-        CU_ASSERT(streamSynchronizeWrapper(CU_STREAM_PER_THREAD));
-
-        if (memcmp(pattern, devicePattern, 1024 * 1024 * 2) != 0) {
-            for (x = 0; x < (1024 * 1024 * 2) / sizeof(unsigned int); x++) {
-                if (devicePattern[x] != pattern[x]) {
-                    std::stringstream errmsg1;
-                    std::stringstream errmsg2;
-                    errmsg1 << " Invalid value when checking the pattern at <" << (void*)((char*)_buffer + n * (1024 * 1024 * 2) + x * sizeof(unsigned int)) << ">";
-                    errmsg2 << " Current offset [ " << (unsigned long long)((char*)_buffer - (char*)buffer) + (unsigned long long)(x * sizeof(unsigned int)) << "/" << (size) << "]";
-                    output->recordErrorCurrentTest(errmsg1.str(), errmsg2.str());
-                    output->print();
-                    std::abort();
-                }
-            
-            }
-        }
-
-        _buffer = (char*)_buffer + (1024 * 1024 * 2);
-    }
-    if (remaining) {
-        CU_ASSERT(cuMemcpyAsync((CUdeviceptr)devicePattern, (CUdeviceptr)_buffer, (size_t)remaining, CU_STREAM_PER_THREAD));
-        CU_ASSERT(streamSynchronizeWrapper(CU_STREAM_PER_THREAD));
-        if (memcmp(pattern, devicePattern, (size_t)remaining) != 0) {
-            for (x = 0; x < remaining / sizeof(unsigned int); x++) {
-                if (devicePattern[x] != pattern[x]) {
-                    std::stringstream errmsg1;
-                    std::stringstream errmsg2;
-                    errmsg1 << " Invalid value when checking the pattern at <" << (void*)((char*)buffer + n * (1024 * 1024 * 2) + x * sizeof(unsigned int)) << ">";
-                    errmsg2 << " Current offset [ " << (unsigned long long)((char*)_buffer - (char*)buffer) + (unsigned long long)(x * sizeof(unsigned int)) << "/" << (size) << "]";
-                    output->recordErrorCurrentTest(errmsg1.str(), errmsg2.str());
-                    output->print();
-                    std::abort();
-                }
-            }
-        }
-    }
-
-    CU_ASSERT(cuMemFreeHost((void*)devicePattern));
-    free(pattern);
-}
-
-void MemcpyBuffer::xorshift2MBPattern(unsigned int* buffer, unsigned int seed) const {
+void xorshift2MBPattern(unsigned int* buffer, unsigned int seed) {
     unsigned int oldValue = seed;
     unsigned int n = 0;
     for (n = 0; n < (1024 * 1024 * 2) / sizeof(unsigned int); n++) {
@@ -125,6 +51,154 @@ void MemcpyBuffer::xorshift2MBPattern(unsigned int* buffer, unsigned int seed) c
         oldValue = value;
         buffer[n] = oldValue;
     }
+}
+
+void memsetPatternHelper(CUstream stream, CUdeviceptr buffer, unsigned long long size, unsigned int seed, std::shared_ptr<NodeHelper> nodeHelper) {
+    unsigned int* h_pattern;
+    CUdeviceptr d_pattern;
+
+    unsigned long long num_elements = size / sizeof(unsigned int);
+    unsigned long long num_pattern_elements = _2MiB / sizeof(unsigned int);
+
+    // Allocate 2MB of pattern
+    CU_ASSERT(cuMemHostAlloc((void**)&h_pattern, sizeof(char) * _2MiB, CU_MEMHOSTALLOC_PORTABLE));
+    xorshift2MBPattern(h_pattern, seed);
+
+    // Copy the pattern to a device buffer
+    CU_ASSERT(cuMemAlloc(&d_pattern, sizeof(char) * _2MiB));
+    CU_ASSERT(cuMemcpyAsync(d_pattern, (CUdeviceptr)h_pattern, sizeof(char) * _2MiB, CU_STREAM_PER_THREAD));
+
+    // Launch the memset kernel
+    CU_ASSERT(memsetKernel(CU_STREAM_PER_THREAD, buffer, d_pattern, num_elements, num_pattern_elements));
+    CU_ASSERT(nodeHelper->streamSynchronizeWrapper(CU_STREAM_PER_THREAD));
+
+    CU_ASSERT(cuMemFreeHost((void*)h_pattern));
+    CU_ASSERT(cuMemFree(d_pattern));
+}
+
+void memclearByWarpParity(CUstream stream, CUdeviceptr buffer, unsigned long long size, bool clearOddWarpIndexed, std::shared_ptr<NodeHelper> nodeHelper) {
+    CU_ASSERT(memclearKernelByWarpParity(CU_STREAM_PER_THREAD, buffer, size, clearOddWarpIndexed));
+    CU_ASSERT(nodeHelper->streamSynchronizeWrapper(CU_STREAM_PER_THREAD));
+}
+
+void MemcpyInitiatorCE::memsetPattern(MemcpyDispatchInfo &info) const {
+    for (int i = 0; i < info.srcBuffers.size(); i++) {
+        CU_ASSERT(cuCtxSetCurrent(info.contexts[i]));
+        memsetPatternHelper(info.streams[i], info.dstBuffers[i]->getBuffer(), info.adjustedCopySizes[i], 0xCAFEBABE, info.nodeHelper);
+        memsetPatternHelper(info.streams[i], info.srcBuffers[i]->getBuffer(), info.adjustedCopySizes[i], 0xBAADF00D, info.nodeHelper);
+    }
+}
+
+void MemcpyInitiatorSM::memsetPattern(MemcpyDispatchInfo &info) const {
+    for (int i = 0; i < info.srcBuffers.size(); i++) {
+        CU_ASSERT(cuCtxSetCurrent(info.contexts[i]));
+        memsetPatternHelper(info.streams[i], info.dstBuffers[i]->getBuffer(), info.adjustedCopySizes[i], 0xCAFEBABE, info.nodeHelper);
+        memsetPatternHelper(info.streams[i], info.srcBuffers[i]->getBuffer(), info.adjustedCopySizes[i], 0xBAADF00D, info.nodeHelper);
+    }
+}
+
+void MemcpyInitiatorMulticastWrite::memsetPattern(MemcpyDispatchInfo &info) const {
+    for (int i = 0; i < info.srcBuffers.size(); i++) {
+        CU_ASSERT(cuCtxSetCurrent(info.contexts[i]));
+        memsetPatternHelper(info.streams[i], info.dstBuffers[i]->getBuffer(), info.adjustedCopySizes[i], 0xCAFEBABE, info.nodeHelper);
+        memsetPatternHelper(info.streams[i], info.srcBuffers[i]->getBuffer(), info.adjustedCopySizes[i], 0xBAADF00D, info.nodeHelper);
+    }
+}
+
+void MemcpyInitiatorSMSplitWarp::memsetPattern(MemcpyDispatchInfo &info) const {
+    for (int i = 0; i < info.srcBuffers.size(); i++) {
+        CU_ASSERT(cuCtxSetCurrent(info.contexts[i]));
+        memsetPatternHelper(info.streams[i], info.dstBuffers[i]->getBuffer(), info.adjustedCopySizes[i], 0xBAADF00D, info.nodeHelper);
+        memsetPatternHelper(info.streams[i], info.srcBuffers[i]->getBuffer(), info.adjustedCopySizes[i], 0xBAADF00D, info.nodeHelper);
+        memclearByWarpParity(info.streams[i], info.dstBuffers[i]->getBuffer(), info.adjustedCopySizes[i], true /* clearOddWarpIndexed */, info.nodeHelper);
+        memclearByWarpParity(info.streams[i], info.srcBuffers[i]->getBuffer(), info.adjustedCopySizes[i], false /* clearOddWarpIndexed */, info.nodeHelper);
+    }
+}
+
+unsigned long long MemcpyInitiatorCE::getAdjustedBandwidth(unsigned long long bandwidth) {
+    return bandwidth;
+}
+
+unsigned long long MemcpyInitiatorSM::getAdjustedBandwidth(unsigned long long bandwidth) {
+    return bandwidth;
+}
+
+unsigned long long MemcpyInitiatorMulticastWrite::getAdjustedBandwidth(unsigned long long bandwidth) {
+    return bandwidth;
+}
+
+unsigned long long MemcpyInitiatorSMSplitWarp::getAdjustedBandwidth(unsigned long long bandwidth) {
+    // For split warp copies, we estimate bandwidth in each direction as 1/2 of measured bandwidth
+    return bandwidth / 2;
+}
+
+// Add this new typedef for the comparison function pointer
+typedef CUresult (*CompareKernelFunc)(CUstream, CUdeviceptr, CUdeviceptr, unsigned int, unsigned int, CUdeviceptr);
+
+void memcmpPatternHelper(CUstream stream, CUdeviceptr buffer, unsigned long long size, unsigned int seed, CompareKernelFunc compareKernel, std::shared_ptr<NodeHelper> nodeHelper) {
+    unsigned int* h_pattern;
+    CUdeviceptr d_pattern;
+    int h_errorFlag = 0;
+    CUdeviceptr d_errorFlag;
+    unsigned long long num_elements = size / sizeof(unsigned int);
+    unsigned long long num_pattern_elements = _2MiB / sizeof(unsigned int);
+
+    // Allocate 2MB of pattern
+    CU_ASSERT(cuMemHostAlloc((void**)&h_pattern, sizeof(char) * _2MiB, CU_MEMHOSTALLOC_PORTABLE));
+    xorshift2MBPattern(h_pattern, seed);
+    CU_ASSERT(cuMemAlloc(&d_pattern, sizeof(char) * _2MiB));
+    CU_ASSERT(cuMemcpyAsync(d_pattern, (CUdeviceptr)h_pattern, sizeof(char) * _2MiB, CU_STREAM_PER_THREAD));
+
+    // setup error flags
+    CU_ASSERT(cuMemAlloc(&d_errorFlag, sizeof(int)));
+    CU_ASSERT(cuMemcpyAsync(d_errorFlag, (CUdeviceptr)&h_errorFlag, sizeof(int), CU_STREAM_PER_THREAD));
+
+    // launch kernel to compare
+    CU_ASSERT(compareKernel(CU_STREAM_PER_THREAD, buffer, d_pattern, num_elements, num_pattern_elements, d_errorFlag));
+    CU_ASSERT(nodeHelper->streamSynchronizeWrapper(CU_STREAM_PER_THREAD));
+    CU_ASSERT(cuMemcpyAsync((CUdeviceptr)&h_errorFlag, d_errorFlag, sizeof(int), CU_STREAM_PER_THREAD));
+
+    CU_ASSERT(cuMemFreeHost((void*)h_pattern));
+    CU_ASSERT(cuMemFree(d_errorFlag));
+    CU_ASSERT(cuMemFree(d_pattern));
+
+    ASSERT(h_errorFlag == 0);
+}
+
+void MemcpyInitiatorCE::memcmpPattern(MemcpyDispatchInfo &info) const {
+    for (int i = 0; i < info.srcBuffers.size(); i++) {
+        CU_ASSERT(cuCtxSetCurrent(info.contexts[i]));
+        memcmpPatternHelper(info.streams[i], info.dstBuffers[i]->getBuffer(), info.adjustedCopySizes[i], 0xBAADF00D, memcmpKernel, info.nodeHelper);
+    }
+}
+
+void MemcpyInitiatorSM::memcmpPattern(MemcpyDispatchInfo &info) const {
+    for (int i = 0; i < info.srcBuffers.size(); i++) {
+        CU_ASSERT(cuCtxSetCurrent(info.contexts[i]));
+        memcmpPatternHelper(info.streams[i], info.dstBuffers[i]->getBuffer(), info.adjustedCopySizes[i], 0xBAADF00D, memcmpKernel, info.nodeHelper);
+    }
+}
+
+void MemcpyInitiatorMulticastWrite::memcmpPattern(MemcpyDispatchInfo &info) const {
+    for (int i = 0; i < info.srcBuffers.size(); i++) {
+        CU_ASSERT(cuCtxSetCurrent(info.contexts[i]));
+        memcmpPatternHelper(info.streams[i], info.dstBuffers[i]->getBuffer(), info.adjustedCopySizes[i], 0xBAADF00D, multicastMemcmpKernel, info.nodeHelper);
+    }
+}
+
+void MemcpyInitiatorSMSplitWarp::memcmpPattern(MemcpyDispatchInfo &info) const {
+    for (int i = 0; i < info.srcBuffers.size(); i++) {
+        CU_ASSERT(cuCtxSetCurrent(info.contexts[i]));
+        // src and dst buffer contents must match after the bidirectional split warp copy
+        memcmpPatternHelper(info.streams[i], info.dstBuffers[i]->getBuffer(), info.adjustedCopySizes[i], 0xBAADF00D, memcmpKernel, info.nodeHelper);
+        memcmpPatternHelper(info.streams[i], info.srcBuffers[i]->getBuffer(), info.adjustedCopySizes[i], 0xBAADF00D, memcmpKernel, info.nodeHelper);
+    }
+}
+
+// Non-multinode MemcpyBuffers will always return Rank 0
+// Semantically, we can assume that non-MPI runs will have world rank = 0 and world size = 1
+int MemcpyBuffer::getMPIRank() const {
+    return 0;
 }
 
 CUresult MemcpyBuffer::streamSynchronizeWrapper(CUstream stream) const {
@@ -208,14 +282,14 @@ bool DeviceBuffer::enablePeerAcess(const DeviceBuffer &peerBuffer) {
     return false;
 }
 
+MemcpyDescriptor::MemcpyDescriptor(CUdeviceptr dst, CUdeviceptr src, CUstream stream, size_t copySize, unsigned long long loopCount) :
+    dst(dst), src(src), stream(stream), copySize(copySize), loopCount(loopCount) {}
+
 MemcpyOperation::MemcpyOperation(unsigned long long loopCount, MemcpyInitiator* memcpyInitiator, ContextPreference ctxPreference, BandwidthValue bandwidthValue) :
-    MemcpyOperation(loopCount, memcpyInitiator, new NodeHelperSingle(), ctxPreference, bandwidthValue)
-{
-}
+    MemcpyOperation(loopCount, memcpyInitiator, new NodeHelperSingle(), ctxPreference, bandwidthValue) {}
 
 MemcpyOperation::MemcpyOperation(unsigned long long loopCount, MemcpyInitiator* memcpyInitiator, NodeHelper* nodeHelper, ContextPreference ctxPreference, BandwidthValue bandwidthValue) :
-        loopCount(loopCount), memcpyInitiator(memcpyInitiator), nodeHelper(nodeHelper), ctxPreference(ctxPreference), bandwidthValue(bandwidthValue)
-{
+        loopCount(loopCount), memcpyInitiator(memcpyInitiator), nodeHelper(nodeHelper), ctxPreference(ctxPreference), bandwidthValue(bandwidthValue) {
     procMask = (size_t *)calloc(1, PROC_MASK_SIZE);
     PROC_MASK_SET(procMask, getFirstEnabledCPU());
 }
@@ -230,9 +304,9 @@ double MemcpyOperation::doMemcpy(const MemcpyBuffer &srcBuffer, const MemcpyBuff
     return doMemcpy(srcBuffers, dstBuffers);
 }
 
-MemcpyDispatchInfo::MemcpyDispatchInfo(std::vector<const MemcpyBuffer*> srcBuffers, std::vector<const MemcpyBuffer*> dstBuffers, std::vector<CUcontext> contexts) :
-    srcBuffers(srcBuffers), dstBuffers(dstBuffers), contexts(contexts)
-{}
+MemcpyDispatchInfo::MemcpyDispatchInfo(std::vector<const MemcpyBuffer*> srcBuffers, std::vector<const MemcpyBuffer*> dstBuffers, std::vector<CUcontext> contexts, std::vector<int> originalRanks) :
+    srcBuffers(srcBuffers), dstBuffers(dstBuffers), contexts(contexts), originalRanks(originalRanks) {
+}
 
 NodeHelperSingle::NodeHelperSingle() {
     CU_ASSERT(cuMemHostAlloc((void **)&blockingVarHost, sizeof(*blockingVarHost), CU_MEMHOSTALLOC_PORTABLE));
@@ -273,7 +347,7 @@ double NodeHelperSingle::calculateFirstBandwidth(std::vector<PerformanceStatisti
     return bandwidthStats[0].returnAppropriateMetric() * 1e-9;
 }
 
-std::vector<double> NodeHelperSingle::calculateVectorBandwidth(std::vector<double> &results) {
+std::vector<double> NodeHelperSingle::calculateVectorBandwidth(std::vector<double> &results, std::vector<int> originalRanks) {
     return results;
 }
 
@@ -300,41 +374,44 @@ void NodeHelperSingle::streamBlockerBlock(CUstream stream) {
 
 double MemcpyOperation::doMemcpy(const std::vector<const MemcpyBuffer*> &srcBuffers, const std::vector<const MemcpyBuffer*> &dstBuffers) {
     MemcpyDispatchInfo dispatchInfo = nodeHelper->dispatchMemcpy(srcBuffers, dstBuffers, ctxPreference);
-    return doMemcpyCore(dispatchInfo.srcBuffers, dispatchInfo.dstBuffers, dispatchInfo.contexts)[0];
+    auto result = doMemcpyCore(dispatchInfo);
+    return result[0];
 }
 
 std::vector<double> MemcpyOperation::doMemcpyVector(const std::vector<const MemcpyBuffer*> &srcBuffers, const std::vector<const MemcpyBuffer*> &dstBuffers) {
     MemcpyDispatchInfo dispatchInfo = nodeHelper->dispatchMemcpy(srcBuffers, dstBuffers, ctxPreference);
-    auto results = doMemcpyCore(dispatchInfo.srcBuffers, dispatchInfo.dstBuffers, dispatchInfo.contexts);
+    auto results = doMemcpyCore(dispatchInfo);
 
-    return nodeHelper->calculateVectorBandwidth(results);
+    return nodeHelper->calculateVectorBandwidth(results, dispatchInfo.originalRanks);
 }
 
-
-std::vector<double> MemcpyOperation::doMemcpyCore(const std::vector<const MemcpyBuffer*> &srcBuffers, const std::vector<const MemcpyBuffer*> &dstBuffers, const std::vector<CUcontext> &contexts) {
-    std::vector<CUstream> streams(srcBuffers.size());
-    std::vector<CUevent> startEvents(srcBuffers.size());
-    std::vector<CUevent> endEvents(srcBuffers.size());
-    std::vector<PerformanceStatistic> bandwidthStats(srcBuffers.size());
-    std::vector<size_t> adjustedCopySizes(srcBuffers.size());
+std::vector<double> MemcpyOperation::doMemcpyCore(MemcpyDispatchInfo &info) {
+    std::vector<CUstream> streams(info.srcBuffers.size());
+    std::vector<CUevent> startEvents(info.srcBuffers.size());
+    std::vector<CUevent> endEvents(info.srcBuffers.size());
+    std::vector<PerformanceStatistic> bandwidthStats(info.srcBuffers.size());
+    std::vector<size_t> adjustedCopySizes(info.srcBuffers.size());
     PerformanceStatistic totalBandwidth;
     CUevent totalEnd;
-    std::vector<size_t> finalCopySize(srcBuffers.size());
+    std::vector<size_t> finalCopySize(info.srcBuffers.size());
 
-    for (int i = 0; i < srcBuffers.size(); i++) {
-        CU_ASSERT(cuCtxSetCurrent(contexts[i]));
+    for (int i = 0; i < info.srcBuffers.size(); i++) {
+        CU_ASSERT(cuCtxSetCurrent(info.contexts[i]));
         // allocate the per simulaneous copy resources
         CU_ASSERT(cuStreamCreate(&streams[i], CU_STREAM_NON_BLOCKING));
+        info.streams.push_back(streams[i]);
         CU_ASSERT(cuEventCreate(&startEvents[i], CU_EVENT_DEFAULT));
         CU_ASSERT(cuEventCreate(&endEvents[i], CU_EVENT_DEFAULT));
         // Get the final copy size that will be used.
         // CE and SM copy sizes will differ due to possible truncation
         // during SM copies.
-        finalCopySize[i] = memcpyInitiator->getAdjustedCopySize(srcBuffers[i]->getBufferSize(), streams[i]);
+        finalCopySize[i] = memcpyInitiator->getAdjustedCopySize(info.srcBuffers[i]->getBufferSize(), streams[i]);
+        info.adjustedCopySizes.push_back(finalCopySize[i]);
     }
-    
-    if (contexts.size() > 0) {
-        CU_ASSERT(cuCtxSetCurrent(contexts[0]));
+    info.nodeHelper = nodeHelper;
+
+    if (info.contexts.size() > 0) {
+        CU_ASSERT(cuCtxSetCurrent(info.contexts[0]));
     }
     // If no memcpy operations are happening on this node, let's still record a totalEnd event to simplify code
     CU_ASSERT(cuEventCreate(&totalEnd, CU_EVENT_DEFAULT));
@@ -344,63 +421,59 @@ std::vector<double> MemcpyOperation::doMemcpyCore(const std::vector<const Memcpy
         nodeHelper->streamBlockerReset();
         nodeHelper->synchronizeProcess();
 
-        // Set the memory patterns correctly before spin kernel launch etc.
-        for (int i = 0; i < srcBuffers.size(); i++) {
-            dstBuffers[i]->memsetPattern(dstBuffers[i]->getBuffer(), finalCopySize[i], 0xCAFEBABE);
-            srcBuffers[i]->memsetPattern(srcBuffers[i]->getBuffer(), finalCopySize[i], 0xBAADF00D);
-        }        
+        memcpyInitiator->memsetPattern(info);
         // block stream, and enqueue copy
-        for (int i = 0; i < srcBuffers.size(); i++) {
-            CU_ASSERT(cuCtxSetCurrent(contexts[i]));
+        for (int i = 0; i < info.srcBuffers.size(); i++) {
+            CU_ASSERT(cuCtxSetCurrent(info.contexts[i]));
 
-            nodeHelper->streamBlockerBlock(streams[i]);
+            nodeHelper->streamBlockerBlock(info.streams[i]);
 
             // warmup
-            memcpyInitiator->memcpyFunc(dstBuffers[i]->getBuffer(), srcBuffers[i]->getBuffer(), streams[i], srcBuffers[i]->getBufferSize(), WARMUP_COUNT);
+            MemcpyDescriptor desc(info.dstBuffers[i]->getBuffer(), info.srcBuffers[i]->getBuffer(), info.streams[i], info.srcBuffers[i]->getBufferSize(), WARMUP_COUNT);
+            memcpyInitiator->memcpyFunc(desc);
         }
 
-        if (srcBuffers.size() > 0) {
-            CU_ASSERT(cuCtxSetCurrent(contexts[0]));
-            CU_ASSERT(cuEventRecord(startEvents[0], streams[0]));
+        if (info.srcBuffers.size() > 0) {
+            CU_ASSERT(cuCtxSetCurrent(info.contexts[0]));
+            CU_ASSERT(cuEventRecord(startEvents[0], info.streams[0]));
         }
 
-        for (int i = 1; i < srcBuffers.size(); i++) {
+        for (int i = 1; i < info.srcBuffers.size(); i++) {
             // ensure that all copies are launched at the same time
-            CU_ASSERT(cuCtxSetCurrent(contexts[i]));
-            CU_ASSERT(cuStreamWaitEvent(streams[i], startEvents[0], 0));
-            CU_ASSERT(cuEventRecord(startEvents[i], streams[i]));
+            CU_ASSERT(cuCtxSetCurrent(info.contexts[i]));
+            CU_ASSERT(cuStreamWaitEvent(info.streams[i], startEvents[0], 0));
+            CU_ASSERT(cuEventRecord(startEvents[i], info.streams[i]));
         }
 
-        for (int i = 0; i < srcBuffers.size(); i++) {
-            CU_ASSERT(cuCtxSetCurrent(contexts[i]));
-            ASSERT(srcBuffers[i]->getBufferSize() == dstBuffers[i]->getBufferSize());
-            adjustedCopySizes[i] = memcpyInitiator->memcpyFunc(dstBuffers[i]->getBuffer(), srcBuffers[i]->getBuffer(), streams[i], srcBuffers[i]->getBufferSize(), loopCount);
-            CU_ASSERT(cuEventRecord(endEvents[i], streams[i]));
+        for (int i = 0; i < info.srcBuffers.size(); i++) {
+            CU_ASSERT(cuCtxSetCurrent(info.contexts[i]));
+            ASSERT(info.srcBuffers[i]->getBufferSize() == info.dstBuffers[i]->getBufferSize());
+            MemcpyDescriptor desc(info.dstBuffers[i]->getBuffer(), info.srcBuffers[i]->getBuffer(), info.streams[i], info.srcBuffers[i]->getBufferSize(), loopCount);
+            adjustedCopySizes[i] = memcpyInitiator->memcpyFunc(desc);
+            CU_ASSERT(cuEventRecord(endEvents[i], info.streams[i]));
             if (bandwidthValue == BandwidthValue::TOTAL_BW && i != 0) {
                 // make stream0 wait on the all the others so we can measure total completion time
-                CU_ASSERT(cuStreamWaitEvent(streams[0], endEvents[i], 0));
+                CU_ASSERT(cuStreamWaitEvent(info.streams[0], endEvents[i], 0));
             }
         }
 
         // record the total end - only valid if BandwidthValue::TOTAL_BW is used due to StreamWaitEvent above
-        if (srcBuffers.size() > 0) {
-            CU_ASSERT(cuCtxSetCurrent(contexts[0]));
-            CU_ASSERT(cuEventRecord(totalEnd, streams[0]));
+        if (info.srcBuffers.size() > 0) {
+            CU_ASSERT(cuCtxSetCurrent(info.contexts[0]));
+            CU_ASSERT(cuEventRecord(totalEnd, info.streams[0]));
         }
 
         // unblock the streams
         nodeHelper->streamBlockerRelease();
 
-        for (CUstream stream : streams) {
+        for (CUstream stream : info.streams) {
             CU_ASSERT(nodeHelper->streamSynchronizeWrapper(stream));
         }
 
         nodeHelper->synchronizeProcess();
 
         if (!skipVerification) {
-            for (int i = 0; i < srcBuffers.size(); i++) {            
-                dstBuffers[i]->memcmpPattern(dstBuffers[i]->getBuffer(), finalCopySize[i], 0xBAADF00D);
-            }
+            memcpyInitiator->memcmpPattern(info);
         }
 
         for (int i = 0; i < bandwidthStats.size(); i++) {
@@ -408,18 +481,23 @@ std::vector<double> MemcpyOperation::doMemcpyCore(const std::vector<const Memcpy
             CU_ASSERT(cuEventElapsedTime(&timeWithEvents, startEvents[i], endEvents[i]));
             double elapsedWithEventsInUs = ((double) timeWithEvents * 1000.0);
             unsigned long long bandwidth = (adjustedCopySizes[i] * loopCount * 1000ull * 1000ull) / (unsigned long long) elapsedWithEventsInUs;
+
+            bandwidth = memcpyInitiator->getAdjustedBandwidth(bandwidth);
+
             bandwidthStats[i]((double) bandwidth);
 
             if (bandwidthValue == BandwidthValue::SUM_BW || BandwidthValue::TOTAL_BW || i == 0) {
                 // Verbose print only the values that are used for the final output
-                VERBOSE << "\tSample " << n << ": " << srcBuffers[i]->getBufferString() << " -> " << dstBuffers[i]->getBufferString() << ": " <<
+                VERBOSE << "\tSample " << n << ": " << info.srcBuffers[i]->getBufferString() << " -> " << info.dstBuffers[i]->getBufferString() << ": " <<
                     std::fixed << std::setprecision(2) << (double)bandwidth * 1e-9 << " GB/s\n";
             }
         }
 
         if (bandwidthValue == BandwidthValue::TOTAL_BW) {
             float totalTime = 0.0f;
-            CU_ASSERT(cuEventElapsedTime(&totalTime, startEvents[0], totalEnd));
+            if (startEvents.size() > 0) {
+                CU_ASSERT(cuEventElapsedTime(&totalTime, startEvents[0], totalEnd));
+            }
             double elapsedTotalInUs = ((double) totalTime * 1000.0);
 
             // get total bytes copied
@@ -438,8 +516,8 @@ std::vector<double> MemcpyOperation::doMemcpyCore(const std::vector<const Memcpy
     // cleanup
     CU_ASSERT(cuEventDestroy(totalEnd));
 
-    for (int i = 0; i < srcBuffers.size(); i++) {
-        CU_ASSERT(cuStreamDestroy(streams[i]));
+    for (int i = 0; i < info.srcBuffers.size(); i++) {
+        CU_ASSERT(cuStreamDestroy(info.streams[i]));
         CU_ASSERT(cuEventDestroy(startEvents[i]));
         CU_ASSERT(cuEventDestroy(endEvents[i]));
     }
@@ -453,15 +531,16 @@ std::vector<double> MemcpyOperation::doMemcpyCore(const std::vector<const Memcpy
         for (auto stat : bandwidthStats) {
             ret.push_back(stat.returnAppropriateMetric() * 1e-9);
         }
-       return ret;
+        return ret;
     } else {
         return {nodeHelper->calculateFirstBandwidth(bandwidthStats)};
     }
 }
 
-size_t MemcpyInitiatorSM::memcpyFunc(CUdeviceptr dst, CUdeviceptr src, CUstream stream, size_t copySize, unsigned long long loopCount) {
-    return copyKernel(dst, src, copySize, stream, loopCount);
+size_t MemcpyInitiatorSM::memcpyFunc(MemcpyDescriptor &desc) {
+    return copyKernel(desc);
 }
+
 size_t MemcpyInitiatorSM::getAdjustedCopySize(size_t size, CUstream stream) {
     CUdevice dev;
     CUcontext ctx;
@@ -473,7 +552,7 @@ size_t MemcpyInitiatorSM::getAdjustedCopySize(size_t size, CUstream stream) {
     unsigned int totalThreadCount = numSm * numThreadPerBlock;
     // We want to calculate the exact copy sizes that will be
     // used by the copy kernels.
-    if (size < (defaultBufferSize * _MiB) ) {
+    if (size < (defaultBufferSize * _MiB)) {
         // copy size is rounded down to 16 bytes
         int numUint4 = size / sizeof(uint4);
         return numUint4 * sizeof(uint4);
@@ -485,21 +564,33 @@ size_t MemcpyInitiatorSM::getAdjustedCopySize(size_t size, CUstream stream) {
     return sizeInElement * sizeof(uint4);
 }
 
-size_t MemcpyInitiatorCE::memcpyFunc(CUdeviceptr dst, CUdeviceptr src, CUstream stream, size_t copySize, unsigned long long loopCount) {
-    for (unsigned int l = 0; l < loopCount; l++) {
-        CU_ASSERT(cuMemcpyAsync(dst, src, copySize, stream));
+size_t MemcpyInitiatorCE::memcpyFunc(MemcpyDescriptor &desc) {
+    for (unsigned int l = 0; l < desc.loopCount; l++) {
+        CU_ASSERT(cuMemcpyAsync(desc.dst, desc.src, desc.copySize, desc.stream));
     }
 
-    return copySize;
+    return desc.copySize;
 }
 
 size_t MemcpyInitiatorCE::getAdjustedCopySize(size_t size, CUstream stream) {
-    //CE does not change/truncate buffer size
+    // CE does not change/truncate buffer size
     return size;
 }
 
-MemPtrChaseOperation::MemPtrChaseOperation(unsigned long long loopCount) : loopCount(loopCount)
-{
+size_t MemcpyInitiatorMulticastWrite::memcpyFunc(MemcpyDescriptor &desc) {
+    return multicastCopy(desc.dst, desc.src, desc.copySize, desc.stream, desc.loopCount);
+}
+
+size_t MemcpyInitiatorMulticastWrite::getAdjustedCopySize(size_t size, CUstream stream) {
+    size = size / sizeof(unsigned);
+    return size * sizeof(unsigned);
+}
+
+size_t MemcpyInitiatorSMSplitWarp::memcpyFunc(MemcpyDescriptor &desc) {
+    return copyKernelSplitWarp(desc);
+}
+
+MemPtrChaseOperation::MemPtrChaseOperation(unsigned long long loopCount) : loopCount(loopCount) {
 }
 
 double MemPtrChaseOperation::doPtrChase(const int srcId, const MemcpyBuffer &peerBuffer) {

--- a/memcpy.h
+++ b/memcpy.h
@@ -15,36 +15,34 @@
  * limitations under the License.
  */
 
-#ifndef MEMCPY_H
-#define MEMCPY_H
+#ifndef MEMCPY_H_
+#define MEMCPY_H_
 
 #include <memory>
 #include "common.h"
 
 class MemcpyBuffer {
-protected:
+ protected:
     void* buffer{};
     size_t bufferSize;
-public:
+ public:
     MemcpyBuffer(size_t bufferSize);
     virtual ~MemcpyBuffer() {}
     CUdeviceptr getBuffer() const;
     size_t getBufferSize() const;
-    
+
     virtual int getBufferIdx() const = 0;
     virtual CUcontext getPrimaryCtx() const = 0;
     virtual std::string getBufferString() const = 0;
-    void memsetPattern(CUdeviceptr buffer, unsigned long long size, unsigned int seed) const;
-    void memcmpPattern(CUdeviceptr buffer, unsigned long long size, unsigned int seed) const;
-    void xorshift2MBPattern(unsigned int* buffer, unsigned int seed) const;
-    // In MPI configuration we want to avoid using blocking functions such as cuStreamSynchronize to adhere to MPI notion of progress 
+    // In MPI configuration we want to avoid using blocking functions such as cuStreamSynchronize to adhere to MPI notion of progress
     // For more details see https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/mpi.html#mpi-progress
     virtual CUresult streamSynchronizeWrapper(CUstream stream) const;
+    virtual int getMPIRank() const;
 };
 
 // Represents the host buffer abstraction
 class HostBuffer : public MemcpyBuffer {
-public:
+ public:
     // NUMA affinity is set here through allocation of memory in the socket group where `targetDeviceId` resides
     HostBuffer(size_t bufferSize, int targetDeviceId);
     ~HostBuffer();
@@ -56,10 +54,10 @@ public:
 
 // Represents the device buffer and context abstraction
 class DeviceBuffer : public MemcpyBuffer {
-private:
+ private:
     int deviceIdx;
     CUcontext primaryCtx{};
-public:
+ public:
     DeviceBuffer(size_t bufferSize, int deviceIdx);
     ~DeviceBuffer();
 
@@ -72,32 +70,37 @@ public:
 
 // Specifies the preferred node's context to do the operation from
 // It's only a preference because if the preferred node is a HostBuffer, it has no context and will fall back to the other node
-enum ContextPreference { 
+enum ContextPreference {
         PREFER_SRC_CONTEXT,    // Prefer the source buffer's context if available
         PREFER_DST_CONTEXT     // Prefer the destination buffer's context if available
 };
 
 class MemcpyOperation;
 
+// forward declaration
+class NodeHelper;
+
 class MemcpyDispatchInfo {
-public:
+ public:
     std::vector<CUcontext> contexts;
+    std::vector<CUstream> streams;
     std::vector<const MemcpyBuffer*> srcBuffers;
     std::vector<const MemcpyBuffer*> dstBuffers;
-
-    MemcpyDispatchInfo(std::vector<const MemcpyBuffer*> srcBuffers, std::vector<const MemcpyBuffer*> dstBuffers, std::vector<CUcontext> contexts);
+    std::vector<int> originalRanks;
+    std::vector<size_t> adjustedCopySizes;
+    std::shared_ptr<NodeHelper> nodeHelper;
+    MemcpyDispatchInfo(std::vector<const MemcpyBuffer*> srcBuffers, std::vector<const MemcpyBuffer*> dstBuffers, std::vector<CUcontext> contexts, std::vector<int> originalRanks = {});
 };
 
 class NodeHelper {
-public:
+ public:
     virtual MemcpyDispatchInfo dispatchMemcpy(const std::vector<const MemcpyBuffer*> &srcBuffers, const std::vector<const MemcpyBuffer*> &dstBuffers, ContextPreference ctxPreference) = 0;
-    
     virtual double calculateTotalBandwidth(double totalTime, double totalSize, size_t loopCount) = 0;
     virtual double calculateSumBandwidth(std::vector<PerformanceStatistic> &bandwidthStats) = 0;
     virtual double calculateFirstBandwidth(std::vector<PerformanceStatistic> &bandwidthStats) = 0;
-    virtual std::vector<double> calculateVectorBandwidth(std::vector<double> &results) = 0;
+    virtual std::vector<double> calculateVectorBandwidth(std::vector<double> &results, std::vector<int> originalRanks) = 0;
     virtual void synchronizeProcess() = 0;
-    // In MPI configuration we want to avoid using blocking functions such as cuStreamSynchronize to adhere to MPI notion of progress 
+    // In MPI configuration we want to avoid using blocking functions such as cuStreamSynchronize to adhere to MPI notion of progress
     // For more details see https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/mpi.html#mpi-progress
     virtual CUresult streamSynchronizeWrapper(CUstream stream) const = 0;
 
@@ -108,16 +111,16 @@ public:
 };
 
 class NodeHelperSingle : public NodeHelper {
-private:
+ private:
     volatile int* blockingVarHost;
-public: 
+ public:
     NodeHelperSingle();
     ~NodeHelperSingle();
     MemcpyDispatchInfo dispatchMemcpy(const std::vector<const MemcpyBuffer*> &srcBuffers, const std::vector<const MemcpyBuffer*> &dstBuffers, ContextPreference ctxPreference);
     double calculateTotalBandwidth(double totalTime, double totalSize, size_t loopCount);
     double calculateSumBandwidth(std::vector<PerformanceStatistic> &bandwidthStats);
     double calculateFirstBandwidth(std::vector<PerformanceStatistic> &bandwidthStats);
-    std::vector<double> calculateVectorBandwidth(std::vector<double> &results);
+    std::vector<double> calculateVectorBandwidth(std::vector<double> &results, std::vector<int> originalRanks);
     void synchronizeProcess();
     CUresult streamSynchronizeWrapper(CUstream stream) const;
 
@@ -128,79 +131,121 @@ public:
 };
 
 class MemcpyInitiator {
-public:
+ public:
     // Pure virtual function for implementation of the actual memcpy function
     // return actual bytes copied
     // This can vary from copySize due to SM copies truncated the copy to achieve max bandwidth
-    virtual size_t memcpyFunc(CUdeviceptr dst, CUdeviceptr src, CUstream stream, size_t copySize, unsigned long long loopCount) = 0;
+    virtual size_t memcpyFunc(MemcpyDescriptor &memcpyDescriptor) = 0;
     // Calculate the truncated sizes used by copy kernels
     virtual size_t getAdjustedCopySize(size_t size, CUstream stream) = 0;
+    // Fill buffer with a pattern
+    virtual void memsetPattern(MemcpyDispatchInfo &info) const = 0;
+    // Compare buffer with a pattern
+    virtual void memcmpPattern(MemcpyDispatchInfo &info) const = 0;
+    // Adjust the bandwidth before final reporting
+    virtual unsigned long long getAdjustedBandwidth(unsigned long long bandwidth) = 0;
 };
 
 class MemcpyInitiatorSM : public MemcpyInitiator {
-public:
-    size_t memcpyFunc(CUdeviceptr dst, CUdeviceptr src, CUstream stream, size_t copySize, unsigned long long loopCount);
+ public:
+    size_t memcpyFunc(MemcpyDescriptor &memcpyDescriptor);
     // Calculate the truncated sizes used by copy kernels
     size_t getAdjustedCopySize(size_t size, CUstream stream);
+    // Fill buffer with a pattern
+    void memsetPattern(MemcpyDispatchInfo &info) const;
+    // Compare buffer with a pattern
+    void memcmpPattern(MemcpyDispatchInfo &info) const;
+    // Adjust the bandwidth before final reporting
+    unsigned long long getAdjustedBandwidth(unsigned long long bandwidth);
 };
 
 class MemcpyInitiatorCE : public MemcpyInitiator  {
-public:
-    size_t memcpyFunc(CUdeviceptr dst, CUdeviceptr src, CUstream stream, size_t copySize, unsigned long long loopCount);
+ public:
+    size_t memcpyFunc(MemcpyDescriptor &memcpyDescriptor);
     // Calculate the truncated sizes used by copy kernels
     size_t getAdjustedCopySize(size_t size, CUstream stream);
+    // Fill buffer with a pattern
+    void memsetPattern(MemcpyDispatchInfo &info) const;
+    // Compare buffer with a pattern
+    void memcmpPattern(MemcpyDispatchInfo &info) const;
+    // Adjust the bandwidth before final reporting
+    unsigned long long getAdjustedBandwidth(unsigned long long bandwidth);
+};
+
+class MemcpyInitiatorMulticastWrite : public MemcpyInitiator {
+ public:
+    size_t memcpyFunc(MemcpyDescriptor &memcpyDescriptor);
+    // Calculate the truncated sizes used by copy kernels
+    size_t getAdjustedCopySize(size_t size, CUstream stream);
+    // Fill buffer with a pattern
+    void memsetPattern(MemcpyDispatchInfo &info) const;
+    // Compare buffer with a pattern
+    void memcmpPattern(MemcpyDispatchInfo &info) const;
+    // Adjust the bandwidth before final reporting
+    unsigned long long getAdjustedBandwidth(unsigned long long bandwidth);
+};
+
+class MemcpyInitiatorSMSplitWarp : public MemcpyInitiatorSM {
+ public:
+    size_t memcpyFunc(MemcpyDescriptor &memcpyDescriptor);
+    // Fill buffer with a pattern
+    void memsetPattern(MemcpyDispatchInfo &info) const;
+    // Compare buffer with a pattern
+    void memcmpPattern(MemcpyDispatchInfo &info) const;
+    // Adjust the bandwidth before final reporting
+    unsigned long long getAdjustedBandwidth(unsigned long long bandwidth);
 };
 
 // Abstraction of a memory Operation.
 class MemoryOperation {
-public:
-    MemoryOperation () = default;
+ public:
+    MemoryOperation() = default;
     ~MemoryOperation() = default;
 };
 
 // Abstraction of a memcpy operation
 class MemcpyOperation : public MemoryOperation {
-public:
+ public:
     // Specifies which bandwidths to use for the final result of simultaneous copies
-    enum BandwidthValue { 
+    enum BandwidthValue {
             USE_FIRST_BW,      // Use the bandwidth of the first copy in the simultaneous copy list
             SUM_BW,            // Use the sum of all bandwidths from the simultaneous copy list
-            TOTAL_BW,           // Use the total bandwidth of all copies, based on total time and total bytes copied
+            TOTAL_BW,          // Use the total bandwidth of all copies, based on total time and total bytes copied
             VECTOR_BW,         // Return bandwidths of each copy separately
     };
 
     ContextPreference ctxPreference;
 
-private:
+ private:
     unsigned long long loopCount;
 
-protected:
+ protected:
     size_t *procMask;
     BandwidthValue bandwidthValue;
 
     std::shared_ptr<NodeHelper> nodeHelper;
     std::shared_ptr<MemcpyInitiator> memcpyInitiator;
 
-public:
+ public:
     MemcpyOperation(unsigned long long loopCount, MemcpyInitiator *_memcpyInitiator, ContextPreference ctxPreference = ContextPreference::PREFER_SRC_CONTEXT, BandwidthValue bandwidthValue = BandwidthValue::USE_FIRST_BW);
     MemcpyOperation(unsigned long long loopCount, MemcpyInitiator *_memcpyInitiator, NodeHelper *_nodeHelper, ContextPreference ctxPreference = ContextPreference::PREFER_SRC_CONTEXT, BandwidthValue bandwidthValue = BandwidthValue::USE_FIRST_BW);
     virtual ~MemcpyOperation();
 
     // Lists of paired nodes will be executed sumultaneously
     // context of srcBuffers is preferred (if not host) unless otherwise specified
-    std::vector<double> doMemcpyCore(const std::vector<const MemcpyBuffer*> &srcBuffers, const std::vector<const MemcpyBuffer*> &dstBuffers, const std::vector<CUcontext> &contexts);
+    std::vector<double> doMemcpyCore(MemcpyDispatchInfo &info);
     std::vector<double> doMemcpyVector(const std::vector<const MemcpyBuffer*> &srcBuffers, const std::vector<const MemcpyBuffer*> &dstBuffers);
     double doMemcpy(const std::vector<const MemcpyBuffer*> &srcBuffers, const std::vector<const MemcpyBuffer*> &dstBuffers);
     double doMemcpy(const MemcpyBuffer &srcBuffer, const MemcpyBuffer &dstBuffer);
 };
 
 class MemPtrChaseOperation : public MemoryOperation {
-public:
+ public:
     MemPtrChaseOperation(unsigned long long loopCount);
     ~MemPtrChaseOperation() = default;
     double doPtrChase(const int srcId, const MemcpyBuffer &peerBuffer);
-private:
+ private:
     unsigned long long loopCount;
 };
 
-#endif
+#endif  // MEMCPY_H_

--- a/multinode_memcpy.cpp
+++ b/multinode_memcpy.cpp
@@ -1,0 +1,327 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef MULTINODE
+#include <mpi.h>
+#include <unistd.h>
+
+#include "kernels.cuh"
+#include "multinode_memcpy.h"
+
+MultinodeMemoryAllocation::MultinodeMemoryAllocation(size_t bufferSize, int MPI_rank): bufferSize(bufferSize), MPI_rank(MPI_rank) {
+    cudaSetDevice(localDevice);
+}
+
+static CUresult MPIstreamSyncHelper(CUstream stream) {
+    CUresult err = CUDA_ERROR_NOT_READY;
+    int flag;
+    while (err == CUDA_ERROR_NOT_READY) {
+        err = cuStreamQuery(stream);
+        MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD, &flag, MPI_STATUS_IGNORE);
+    }
+    return err;
+}
+
+CUresult MultinodeMemoryAllocation::streamSynchronizeWrapper(CUstream stream) const {
+    return MPIstreamSyncHelper(stream);
+}
+
+MultinodeMemoryAllocationUnicast::MultinodeMemoryAllocationUnicast(size_t bufferSize, int MPI_rank): MultinodeMemoryAllocation(bufferSize, MPI_rank) {
+    handleType = CU_MEM_HANDLE_TYPE_FABRIC;
+    prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    prop.location.id = localDevice;
+    prop.requestedHandleTypes = handleType;
+
+    size_t granularity = 0;
+    CU_ASSERT(cuMemGetAllocationGranularity(&granularity, &prop, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED));
+
+    roundedUpAllocationSize = ROUND_UP(bufferSize, granularity);
+
+    if (MPI_rank == worldRank) {
+        // Allocate the memory
+        CU_ASSERT(cuMemCreate(&handle, roundedUpAllocationSize, &prop, 0 /*flags*/));
+
+        // Export the allocation to the importing process
+        CU_ASSERT(cuMemExportToShareableHandle(&fh, handle, handleType, 0 /*flags*/));
+    }
+
+    MPI_Bcast(&fh, sizeof(fh), MPI_BYTE, MPI_rank, MPI_COMM_WORLD);
+
+    if (MPI_rank != worldRank) {
+        CU_ASSERT(cuMemImportFromShareableHandle(&handle, (void *)&fh, handleType));
+    }
+
+    // Map the memory
+    CU_ASSERT(cuMemAddressReserve((CUdeviceptr *) &buffer, roundedUpAllocationSize, 0, 0 /*baseVA*/, 0 /*flags*/));
+
+    CU_ASSERT(cuMemMap((CUdeviceptr) buffer, roundedUpAllocationSize, 0 /*offset*/, handle, 0 /*flags*/));
+    desc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    desc.location.id = localDevice;
+    desc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+    CU_ASSERT(cuMemSetAccess((CUdeviceptr) buffer, roundedUpAllocationSize, &desc, 1 /*count*/));
+
+    // Make sure that everyone is done with mapping the fabric allocation
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+MultinodeMemoryAllocationUnicast::~MultinodeMemoryAllocationUnicast() {
+    // Make sure that everyone is done using the memory
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    CU_ASSERT(cuMemUnmap((CUdeviceptr) buffer, roundedUpAllocationSize));
+    CU_ASSERT(cuMemRelease(handle));
+    CU_ASSERT(cuMemAddressFree((CUdeviceptr) buffer, roundedUpAllocationSize));
+}
+
+MultinodeMemoryAllocationMulticast::MultinodeMemoryAllocationMulticast(size_t bufferSize, int MPI_rank): MultinodeMemoryAllocation(bufferSize, MPI_rank) {
+    handleType = CU_MEM_HANDLE_TYPE_FABRIC;
+    multicastProp.numDevices = worldSize;
+    multicastProp.handleTypes = handleType;
+    size_t gran;
+    CU_ASSERT(cuMulticastGetGranularity(&gran, &multicastProp, CU_MULTICAST_GRANULARITY_RECOMMENDED));
+    roundedUpAllocationSize = ROUND_UP(bufferSize, gran);
+    multicastProp.size = roundedUpAllocationSize;
+
+    if (MPI_rank == worldRank) {
+        // Allocate the memory
+        CU_ASSERT(cuMulticastCreate(&multicastHandle, &multicastProp));
+
+        // Export the allocation to the importing process
+        CU_ASSERT(cuMemExportToShareableHandle(&fh, multicastHandle, handleType, 0 /*flags*/));
+    }
+
+    MPI_Bcast(&fh, sizeof(fh), MPI_BYTE, MPI_rank, MPI_COMM_WORLD);
+
+    if (MPI_rank != worldRank) {
+        CU_ASSERT(cuMemImportFromShareableHandle(&multicastHandle, (void *)&fh, handleType));
+    }
+
+    CUdevice dev;
+    CU_ASSERT(cuDeviceGet(&dev, localDevice));
+    CU_ASSERT(cuMulticastAddDevice(multicastHandle, dev));
+
+    // Ensure all devices in this process are added BEFORE binding mem on any device
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Allocate the memory (same as unicast) and bind to MC handle
+    CUmemAllocationProp prop = {};
+    prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    prop.location.id = localDevice;
+    prop.requestedHandleTypes = handleType;
+    CU_ASSERT(cuMemCreate(&handle, roundedUpAllocationSize, &prop, 0 /*flags*/));
+    CU_ASSERT(cuMulticastBindMem(multicastHandle, 0, handle, 0, roundedUpAllocationSize, 0));
+
+    // Map the memory
+    CU_ASSERT(cuMemAddressReserve((CUdeviceptr *) &buffer, roundedUpAllocationSize, 0, 0 /*baseVA*/, 0 /*flags*/));
+
+    CU_ASSERT(cuMemMap((CUdeviceptr) buffer, roundedUpAllocationSize, 0 /*offset*/, multicastHandle, 0 /*flags*/));
+    desc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    desc.location.id = localDevice;
+    desc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+    CU_ASSERT(cuMemSetAccess((CUdeviceptr) buffer, roundedUpAllocationSize, &desc, 1 /*count*/));
+
+    // Make sure that everyone is done with mapping the fabric allocation
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+MultinodeMemoryAllocationMulticast::~MultinodeMemoryAllocationMulticast() {
+    // Make sure that everyone is done using the memory
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    CUdevice dev;
+    CU_ASSERT(cuDeviceGet(&dev, localDevice));
+    CU_ASSERT(cuMulticastUnbind(multicastHandle, dev, 0, roundedUpAllocationSize));
+    CU_ASSERT(cuMemRelease(handle));
+
+    CU_ASSERT(cuMemUnmap((CUdeviceptr) buffer, roundedUpAllocationSize));
+    CU_ASSERT(cuMemRelease(multicastHandle));
+    CU_ASSERT(cuMemAddressFree((CUdeviceptr) buffer, roundedUpAllocationSize));
+}
+
+MultinodeDeviceBuffer::MultinodeDeviceBuffer(size_t bufferSize, int MPI_rank):
+    MPI_rank(MPI_rank),
+    MemcpyBuffer(bufferSize) {
+}
+
+int MultinodeDeviceBuffer::getBufferIdx() const {
+    // only single-GPU supported for now
+    return 0;
+}
+
+std::string MultinodeDeviceBuffer::getBufferString() const {
+    return "Multinode node " + std::to_string(MPI_rank);
+}
+
+CUcontext MultinodeDeviceBuffer::getPrimaryCtx() const {
+    CUcontext primaryCtx;
+    CU_ASSERT(cuDevicePrimaryCtxRetain(&primaryCtx, localDevice));
+    return primaryCtx;
+}
+
+int MultinodeDeviceBuffer::getMPIRank() const {
+    return MPI_rank;
+}
+
+MultinodeDeviceBufferUnicast::MultinodeDeviceBufferUnicast(size_t bufferSize, int MPI_rank):
+    MultinodeDeviceBuffer(bufferSize, MPI_rank),
+    MemoryAllocation(bufferSize, MPI_rank) {
+    buffer = MemoryAllocation.getBuffer();
+}
+
+MultinodeDeviceBufferMulticast::MultinodeDeviceBufferMulticast(size_t bufferSize, int MPI_rank):
+    MultinodeDeviceBuffer(bufferSize, MPI_rank),
+    MemoryAllocation(bufferSize, MPI_rank) {
+    buffer = MemoryAllocation.getBuffer();
+}
+
+MultinodeDeviceBufferLocal::MultinodeDeviceBufferLocal(size_t bufferSize, int MPI_rank):
+    MultinodeDeviceBuffer(bufferSize, MPI_rank) {
+    buffer = nullptr;
+    if (worldRank == MPI_rank) {
+        CU_ASSERT(cuDevicePrimaryCtxRetain(&primaryCtx, localDevice));
+        CU_ASSERT(cuCtxSetCurrent(primaryCtx));
+        if (bufferSize) {
+            CU_ASSERT(cuMemAlloc((CUdeviceptr*)&buffer, bufferSize));
+        }
+    }
+}
+
+MultinodeDeviceBufferLocal::~MultinodeDeviceBufferLocal() {
+    if (buffer) {
+        CU_ASSERT(cuCtxSetCurrent(primaryCtx));
+        CU_ASSERT(cuMemFree((CUdeviceptr)buffer));
+        CU_ASSERT(cuDevicePrimaryCtxRelease(localDevice));
+    }
+}
+
+NodeHelperMulti::NodeHelperMulti() : blockingVarDeviceAllocation(sizeof(*blockingVarDevice), 0)  {
+    CU_ASSERT(cuMemHostAlloc((void **)&blockingVarHost, sizeof(*blockingVarHost), CU_MEMHOSTALLOC_PORTABLE));
+    blockingVarDevice = (volatile int*) blockingVarDeviceAllocation.getBuffer();
+}
+
+NodeHelperMulti::~NodeHelperMulti() {
+    CU_ASSERT(cuMemFreeHost((void*)blockingVarHost));
+}
+
+MemcpyDispatchInfo NodeHelperMulti::dispatchMemcpy(const std::vector<const MemcpyBuffer*> &srcNodesUnfiltered, const std::vector<const MemcpyBuffer*> &dstNodesUnfiltered, ContextPreference ctxPreference) {
+    std::vector<int> ranksUnfiltered(srcNodesUnfiltered.size(), -1);
+    std::vector<CUcontext> contextsUnfiltered(srcNodesUnfiltered.size());
+    std::vector<const MemcpyBuffer*> srcNodes;
+    std::vector<const MemcpyBuffer*> dstNodes;
+    std::vector<CUcontext> contexts;
+
+    for (int i = 0; i < srcNodesUnfiltered.size(); i++) {
+        // prefer source context
+        // determine which ranks executes given operation
+        if (ctxPreference == PREFER_SRC_CONTEXT && srcNodesUnfiltered[i]->getPrimaryCtx() != nullptr) {
+            contextsUnfiltered[i] = srcNodesUnfiltered[i]->getPrimaryCtx();
+            ranksUnfiltered[i] = srcNodesUnfiltered[i]->getMPIRank();
+        } else if (dstNodesUnfiltered[i]->getPrimaryCtx() != nullptr) {
+            contextsUnfiltered[i] = dstNodesUnfiltered[i]->getPrimaryCtx();
+            ranksUnfiltered[i] = dstNodesUnfiltered[i]->getMPIRank();
+        }
+    }
+
+    for (int i = 0; i < srcNodesUnfiltered.size(); i++) {
+        if (ranksUnfiltered[i] == worldRank) {
+            srcNodes.push_back(srcNodesUnfiltered[i]);
+            dstNodes.push_back(dstNodesUnfiltered[i]);
+            contexts.push_back(contextsUnfiltered[i]);
+        }
+    }
+
+    // Don't crash if there are no memcopies to do
+    if (ranksUnfiltered.size() > 0) {
+        rankOfFirstMemcpy = ranksUnfiltered[0];
+    }
+
+    return MemcpyDispatchInfo(srcNodes, dstNodes, contexts, ranksUnfiltered);
+}
+
+double NodeHelperMulti::calculateTotalBandwidth(double totalTime, double totalSize, size_t loopCount) {
+    double totalMax = 0;
+    MPI_Allreduce(&totalTime, &totalMax, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+    totalTime = totalMax;
+
+    double totalSum = 0;
+    MPI_Allreduce(&totalSize, &totalSum, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    totalSize = totalSum;
+
+    return (totalSize * loopCount * 1000ull * 1000ull) / totalTime;
+}
+
+double NodeHelperMulti::calculateSumBandwidth(std::vector<PerformanceStatistic> &bandwidthStats) {
+    double sum = 0.0;
+    for (auto stat : bandwidthStats) {
+        sum += stat.returnAppropriateMetric() * 1e-9;
+    }
+    // Calculate total BW sum across all nodes and memcopies
+    double totalSum = 0;
+    MPI_Allreduce(&sum, &totalSum, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    return totalSum;
+}
+
+double NodeHelperMulti::calculateFirstBandwidth(std::vector<PerformanceStatistic> &bandwidthStats) {
+    // Broadcast bandwidth of "first" memcopy to other nodes
+    double retval = 0;
+    if (worldRank == rankOfFirstMemcpy) {
+        retval = bandwidthStats[0].returnAppropriateMetric() * 1e-9;
+    }
+    MPI_Bcast(&retval, 1, MPI_DOUBLE, rankOfFirstMemcpy, MPI_COMM_WORLD);
+    return retval;
+}
+
+std::vector<double> NodeHelperMulti::calculateVectorBandwidth(std::vector<double> &results, std::vector<int> originalRanks) {
+    std::vector<double> retval;
+    int current_local_elem = 0;
+    for (int i = 0; i < originalRanks.size(); i++) {
+        double tmp = 0;
+        if (worldRank == originalRanks[i]) {
+            tmp = results[current_local_elem];
+            current_local_elem++;
+        }
+        MPI_Bcast(&tmp, 1, MPI_DOUBLE, originalRanks[i], MPI_COMM_WORLD);
+        retval.push_back(tmp);
+    }
+    return retval;
+}
+
+void NodeHelperMulti::synchronizeProcess() {
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+CUresult NodeHelperMulti::streamSynchronizeWrapper(CUstream stream) const {
+    return MPIstreamSyncHelper(stream);
+}
+
+void NodeHelperMulti::streamBlockerReset() {
+    *blockingVarHost = 0;
+    CU_ASSERT(cuMemsetD32((CUdeviceptr) blockingVarDevice, 0, 1));
+}
+
+void NodeHelperMulti::streamBlockerRelease() {
+    *blockingVarHost = 1;
+}
+
+void NodeHelperMulti::streamBlockerBlock(CUstream stream) {
+    // MPI rank ranks[0] is released by blockingVar, writes to blockingVarDevice, releasing other ranks
+    CU_ASSERT(spinKernelMultistage((worldRank == rankOfFirstMemcpy) ? blockingVarHost : nullptr, blockingVarDevice, stream));
+}
+
+#endif  // MULTINODE

--- a/multinode_memcpy.h
+++ b/multinode_memcpy.h
@@ -1,0 +1,148 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MULTINODE_MEMCPY_H_
+#define MULTINODE_MEMCPY_H_
+#ifdef MULTINODE
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+
+#include "common.h"
+#include "memcpy.h"
+
+class MultinodeMemoryAllocation {
+ protected:
+    void* buffer = nullptr;
+    size_t bufferSize;
+    int MPI_rank;
+
+ public:
+    MultinodeMemoryAllocation(size_t bufferSize, int MPI_rank);
+    void *getBuffer() { return (void *) buffer; }
+    CUresult streamSynchronizeWrapper(CUstream stream) const;
+};
+
+// Class responsible for allocating memory that is shareable on a NVLink system, following RAII principles
+// Constructor takes as parameters:
+// - bufferSize: size of requested allocation
+// - MPI_rank: node on which the allocation physically resides.
+//      All other nodes will have this allocation mapped and accessible remotely.
+class MultinodeMemoryAllocationUnicast : public MultinodeMemoryAllocation {
+ private:
+    CUmemGenericAllocationHandle handle = {};
+    CUmemFabricHandle fh = {};
+    CUmemAllocationHandleType handleType = {};
+    CUmemAllocationProp prop = {};
+    CUmemAccessDesc desc = {};
+    size_t roundedUpAllocationSize;
+
+ public:
+    MultinodeMemoryAllocationUnicast(size_t bufferSize, int MPI_rank);
+    ~MultinodeMemoryAllocationUnicast();
+};
+
+// Class responsible for allocating multicast object, following RAII principles
+// Constructor takes as parameters:
+// - bufferSize: size of requested allocation
+// - MPI_rank: node driving the allocation process and exporting memory handle.
+//      All nodes will have this allocation mapped and accessible.
+class MultinodeMemoryAllocationMulticast : public MultinodeMemoryAllocation {
+ private:
+    CUmemGenericAllocationHandle handle = {};
+    CUmemGenericAllocationHandle multicastHandle = {};
+    CUmemFabricHandle fh = {};
+    CUmemAllocationHandleType handleType = {};
+    CUmulticastObjectProp multicastProp = {};
+    CUmemAccessDesc desc = {};
+    size_t roundedUpAllocationSize;
+ public:
+    MultinodeMemoryAllocationMulticast(size_t bufferSize, int MPI_rank);
+    ~MultinodeMemoryAllocationMulticast();
+};
+
+// Class responsible for implementing Multinode MemcpyBuffer
+// Each instance has information about which node owns the memory
+class MultinodeDeviceBuffer : public MemcpyBuffer {
+ private:
+    int MPI_rank;
+ public:
+    MultinodeDeviceBuffer(size_t bufferSize, int MPI_rank);
+
+    virtual CUcontext getPrimaryCtx() const override;
+    virtual int getBufferIdx() const override;
+    virtual std::string getBufferString() const override;
+    virtual int getMPIRank() const override;
+};
+
+// MemcpyBuffer containing memory accessible from a different node in a multi-node NVLink connected system
+// MPI_rank node owns the memory allocation, other nodes have it mapped
+// Writes/reads to that memory from other nodes happen over NVLink
+class MultinodeDeviceBufferUnicast : public MultinodeDeviceBuffer {
+ private:
+    MultinodeMemoryAllocationUnicast MemoryAllocation;
+ public:
+    MultinodeDeviceBufferUnicast(size_t bufferSize, int MPI_rank);
+};
+
+// MemcpyBuffer containing memory bound to multicast object
+// Each node has its own copy of the memory, and the copies are the same
+// Writes to this memory are instantly propagated to other nodes (conforming to P2P writes memory model)
+class MultinodeDeviceBufferMulticast : public MultinodeDeviceBuffer {
+ private:
+    MultinodeMemoryAllocationMulticast MemoryAllocation;
+ public:
+    MultinodeDeviceBufferMulticast(size_t bufferSize, int MPI_rank);
+};
+
+// MemcpyBuffer containing regular device memory
+// Only available on one node, exists primarily to simplify writing testcases
+class MultinodeDeviceBufferLocal : public MultinodeDeviceBuffer {
+ private:
+    CUcontext primaryCtx {};
+ public:
+    MultinodeDeviceBufferLocal(size_t bufferSize, int MPI_rank);
+    ~MultinodeDeviceBufferLocal();
+};
+
+class NodeHelperMulti : public NodeHelper {
+ private:
+    int rankOfFirstMemcpy;
+
+    // streamBlocker
+    volatile int* blockingVarHost;
+    volatile int* blockingVarDevice;
+    MultinodeMemoryAllocationUnicast blockingVarDeviceAllocation;
+ public:
+    NodeHelperMulti();
+    ~NodeHelperMulti();
+    MemcpyDispatchInfo dispatchMemcpy(const std::vector<const MemcpyBuffer*> &srcBuffers, const std::vector<const MemcpyBuffer*> &dstBuffers, ContextPreference ctxPreference);
+    double calculateTotalBandwidth(double totalTime, double totalSize, size_t loopCount);
+    double calculateSumBandwidth(std::vector<PerformanceStatistic> &bandwidthStats);
+    double calculateFirstBandwidth(std::vector<PerformanceStatistic> &bandwidthStats);
+    std::vector<double> calculateVectorBandwidth(std::vector<double> &results, std::vector<int> originalRanks);
+    void synchronizeProcess();
+    CUresult streamSynchronizeWrapper(CUstream stream) const;
+
+    // stream blocking functions
+    void streamBlockerReset();
+    void streamBlockerRelease();
+    void streamBlockerBlock(CUstream stream);
+};
+
+#endif  // MULTINODE
+#endif  // MULTINODE_MEMCPY_H_

--- a/multinode_testcases.cpp
+++ b/multinode_testcases.cpp
@@ -1,0 +1,383 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuda.h>
+
+#include "testcase.h"
+#include "memcpy.h"
+#include "common.h"
+#include "output.h"
+#ifdef MULTINODE
+#include <mpi.h>
+#include "multinode_memcpy.h"
+
+// DtoD Read test - copy from dst to src (backwards) using src contxt
+void MultinodeDeviceToDeviceReadCE::run(unsigned long long size, unsigned long long loopCount) {
+    PeerValueMatrix<double> bandwidthValues(worldSize, worldSize, key);
+    MemcpyOperation memcpyInstance(loopCount, new MemcpyInitiatorCE(), new NodeHelperMulti(), PREFER_DST_CONTEXT);
+
+    for (int srcDeviceId = 0; srcDeviceId < worldSize; srcDeviceId++) {
+        for (int peerDeviceId = 0; peerDeviceId < worldSize; peerDeviceId++) {
+            if (peerDeviceId == srcDeviceId) {
+                continue;
+            }
+            MultinodeDeviceBufferUnicast srcNode(size, srcDeviceId);
+            MultinodeDeviceBufferUnicast peerNode(size, peerDeviceId);
+
+            // swap src and peer nodes, but use srcNodes (the copy's destination) context
+            bandwidthValues.value(srcDeviceId, peerDeviceId) = memcpyInstance.doMemcpy(peerNode, srcNode);
+        }
+    }
+
+    output->addTestcaseResults(bandwidthValues, "memcpy CE GPU(row) -> GPU(column) bandwidth (GB/s)");
+}
+
+
+// DtoD Write test - copy from src to dst using src context
+void MultinodeDeviceToDeviceWriteCE::run(unsigned long long size, unsigned long long loopCount) {
+    PeerValueMatrix<double> bandwidthValues(worldSize, worldSize, key);
+    MemcpyOperation memcpyInstance(loopCount, new MemcpyInitiatorCE(), new NodeHelperMulti());
+
+    for (int srcDeviceId = 0; srcDeviceId < worldSize; srcDeviceId++) {
+        for (int peerDeviceId = 0; peerDeviceId < worldSize; peerDeviceId++) {
+            if (peerDeviceId == srcDeviceId) {
+                continue;
+            }
+
+            MultinodeDeviceBufferUnicast srcNode(size, srcDeviceId);
+            MultinodeDeviceBufferUnicast peerNode(size, peerDeviceId);
+
+            bandwidthValues.value(srcDeviceId, peerDeviceId) = memcpyInstance.doMemcpy(srcNode, peerNode);
+        }
+    }
+
+    output->addTestcaseResults(bandwidthValues, "memcpy CE GPU(row) <- GPU(column) bandwidth (GB/s)");
+}
+
+// DtoD Bidir Read test - copy from dst to src (backwards) using src contxt
+void MultinodeDeviceToDeviceBidirReadCE::run(unsigned long long size, unsigned long long loopCount) {
+    MemcpyOperation memcpyInstance(loopCount, new MemcpyInitiatorCE(), new NodeHelperMulti(), PREFER_DST_CONTEXT, MemcpyOperation::VECTOR_BW);
+    PeerValueMatrix<double> bandwidthValuesRead1(worldSize, worldSize, key + "_read1");
+    PeerValueMatrix<double> bandwidthValuesRead2(worldSize, worldSize, key + "_read2");
+    PeerValueMatrix<double> bandwidthValuesTotal(worldSize, worldSize, key + "_total");
+
+    for (int srcDeviceId = 0; srcDeviceId < worldSize; srcDeviceId++) {
+        for (int peerDeviceId = 0; peerDeviceId < worldSize; peerDeviceId++) {
+            if (peerDeviceId == srcDeviceId) {
+                continue;
+            }
+
+            // Double the size of the interference copy to ensure it interferes correctly
+            MultinodeDeviceBufferUnicast src1(size, srcDeviceId), src2(size, srcDeviceId);
+            MultinodeDeviceBufferUnicast peer1(size, peerDeviceId), peer2(size, peerDeviceId);
+
+            // swap src and peer nodes, but use srcNodes (the copy's destination) context
+            std::vector<const MemcpyBuffer*> srcNodes = {&peer1, &src2};
+            std::vector<const MemcpyBuffer*> peerNodes = {&src1, &peer2};
+
+            auto results = memcpyInstance.doMemcpyVector(srcNodes, peerNodes);
+            bandwidthValuesRead1.value(srcDeviceId, peerDeviceId) = results[0];
+            bandwidthValuesRead2.value(srcDeviceId, peerDeviceId) = results[1];
+            bandwidthValuesTotal.value(srcDeviceId, peerDeviceId) = results[0] + results[1];
+        }
+    }
+
+    output->addTestcaseResults(bandwidthValuesRead1, "memcpy CE CPU(row) <-> GPU(column) Read1 bandwidth (GB/s)");
+    output->addTestcaseResults(bandwidthValuesRead2, "memcpy CE CPU(row) <-> GPU(column) Read2 bandwidth (GB/s)");
+    output->addTestcaseResults(bandwidthValuesTotal, "memcpy CE CPU(row) <-> GPU(column) Total bandwidth (GB/s)");
+}
+
+// DtoD Bidir Write test - copy from src to dst using src context
+void MultinodeDeviceToDeviceBidirWriteCE::run(unsigned long long size, unsigned long long loopCount) {
+    MemcpyOperation memcpyInstance(loopCount, new MemcpyInitiatorCE(), new NodeHelperMulti(), PREFER_SRC_CONTEXT, MemcpyOperation::VECTOR_BW);
+    PeerValueMatrix<double> bandwidthValuesWrite1(worldSize, worldSize, key + "_write1");
+    PeerValueMatrix<double> bandwidthValuesWrite2(worldSize, worldSize, key + "_write2");
+    PeerValueMatrix<double> bandwidthValuesTotal(worldSize, worldSize, key + "_total");
+
+    for (int srcDeviceId = 0; srcDeviceId < worldSize; srcDeviceId++) {
+        for (int peerDeviceId = 0; peerDeviceId < worldSize; peerDeviceId++) {
+            if (peerDeviceId == srcDeviceId) {
+                continue;
+            }
+
+            // Double the size of the interference copy to ensure it interferes correctly
+            MultinodeDeviceBufferUnicast src1(size, srcDeviceId), src2(size, srcDeviceId);
+            MultinodeDeviceBufferUnicast peer1(size, peerDeviceId), peer2(size, peerDeviceId);
+
+            std::vector<const MemcpyBuffer*> srcNodes = {&src1, &peer2};
+            std::vector<const MemcpyBuffer*> peerNodes = {&peer1, &src2};
+
+            auto results = memcpyInstance.doMemcpyVector(srcNodes, peerNodes);
+            bandwidthValuesWrite1.value(srcDeviceId, peerDeviceId) = results[0];
+            bandwidthValuesWrite2.value(srcDeviceId, peerDeviceId) = results[1];
+            bandwidthValuesTotal.value(srcDeviceId, peerDeviceId) = results[0] + results[1];
+        }
+    }
+
+    output->addTestcaseResults(bandwidthValuesWrite1, "memcpy CE CPU(row) <-> GPU(column) Read1 bandwidth (GB/s)");
+    output->addTestcaseResults(bandwidthValuesWrite2, "memcpy CE CPU(row) <-> GPU(column) Read2 bandwidth (GB/s)");
+    output->addTestcaseResults(bandwidthValuesTotal, "memcpy CE CPU(row) <-> GPU(column) Total bandwidth (GB/s)");
+}
+
+
+// DtoD Read test - copy from dst to src (backwards) using src contxt
+void MultinodeDeviceToDeviceReadSM::run(unsigned long long size, unsigned long long loopCount) {
+    PeerValueMatrix<double> bandwidthValues(worldSize, worldSize, key);
+    MemcpyOperation memcpyInstance(loopCount, new MemcpyInitiatorSM(), new NodeHelperMulti(), PREFER_DST_CONTEXT);
+
+    for (int srcDeviceId = 0; srcDeviceId < worldSize; srcDeviceId++) {
+        for (int peerDeviceId = 0; peerDeviceId < worldSize; peerDeviceId++) {
+            if (peerDeviceId == srcDeviceId) {
+                continue;
+            }
+
+            MultinodeDeviceBufferUnicast srcNode(size, srcDeviceId);
+            MultinodeDeviceBufferUnicast peerNode(size, peerDeviceId);
+
+            // swap src and peer nodes, but use srcNodes (the copy's destination) context
+            bandwidthValues.value(srcDeviceId, peerDeviceId) = memcpyInstance.doMemcpy(peerNode, srcNode);
+        }
+    }
+
+    output->addTestcaseResults(bandwidthValues, "memcpy CE GPU(row) -> GPU(column) bandwidth (GB/s)");
+}
+
+// DtoD Write test - copy from src to dst using src context
+void MultinodeDeviceToDeviceWriteSM::run(unsigned long long size, unsigned long long loopCount) {
+    PeerValueMatrix<double> bandwidthValues(worldSize, worldSize, key);
+    MemcpyOperation memcpyInstance(loopCount, new MemcpyInitiatorSM(), new NodeHelperMulti());
+
+    for (int srcDeviceId = 0; srcDeviceId < worldSize; srcDeviceId++) {
+        for (int peerDeviceId = 0; peerDeviceId < worldSize; peerDeviceId++) {
+            if (peerDeviceId == srcDeviceId) {
+                continue;
+            }
+
+            MultinodeDeviceBufferUnicast srcNode(size, srcDeviceId);
+            MultinodeDeviceBufferUnicast peerNode(size, peerDeviceId);
+
+            bandwidthValues.value(srcDeviceId, peerDeviceId) = memcpyInstance.doMemcpy(srcNode, peerNode);
+        }
+    }
+
+    output->addTestcaseResults(bandwidthValues, "memcpy SM GPU(row) <- GPU(column) bandwidth (GB/s)");
+}
+
+// DtoD Bidir Read test - copy from dst to src (backwards) using src contxt
+void MultinodeDeviceToDeviceBidirReadSM::run(unsigned long long size, unsigned long long loopCount) {
+    MemcpyOperation memcpyInstance(loopCount, new MemcpyInitiatorSM(), new NodeHelperMulti(), PREFER_DST_CONTEXT, MemcpyOperation::VECTOR_BW);
+    PeerValueMatrix<double> bandwidthValuesRead1(worldSize, worldSize, key + "_read1");
+    PeerValueMatrix<double> bandwidthValuesRead2(worldSize, worldSize, key + "_read2");
+    PeerValueMatrix<double> bandwidthValuesTotal(worldSize, worldSize, key + "_total");
+
+    for (int srcDeviceId = 0; srcDeviceId < worldSize; srcDeviceId++) {
+        for (int peerDeviceId = 0; peerDeviceId < worldSize; peerDeviceId++) {
+            if (peerDeviceId == srcDeviceId) {
+                continue;
+            }
+
+            MultinodeDeviceBufferUnicast src1(size, srcDeviceId), src2(size, srcDeviceId);
+            MultinodeDeviceBufferUnicast peer1(size, peerDeviceId), peer2(size, peerDeviceId);
+
+            // swap src and peer nodes, but use srcNodes (the copy's destination) context
+            std::vector<const MemcpyBuffer*> srcNodes = {&peer1, &src2};
+            std::vector<const MemcpyBuffer*> peerNodes = {&src1, &peer2};
+
+            auto results = memcpyInstance.doMemcpyVector(srcNodes, peerNodes);
+            bandwidthValuesRead1.value(srcDeviceId, peerDeviceId) = results[0];
+            bandwidthValuesRead2.value(srcDeviceId, peerDeviceId) = results[1];
+            bandwidthValuesTotal.value(srcDeviceId, peerDeviceId) = results[0] + results[1];
+        }
+    }
+
+    output->addTestcaseResults(bandwidthValuesRead1, "memcpy SM CPU(row) <-> GPU(column) Read1 bandwidth (GB/s)");
+    output->addTestcaseResults(bandwidthValuesRead2, "memcpy SM CPU(row) <-> GPU(column) Read2 bandwidth (GB/s)");
+    output->addTestcaseResults(bandwidthValuesTotal, "memcpy SM CPU(row) <-> GPU(column) Total bandwidth (GB/s)");
+}
+
+// DtoD Bidir Write test - copy from src to dst using src context
+void MultinodeDeviceToDeviceBidirWriteSM::run(unsigned long long size, unsigned long long loopCount) {
+    MemcpyOperation memcpyInstance(loopCount, new MemcpyInitiatorSM(), new NodeHelperMulti(), PREFER_SRC_CONTEXT, MemcpyOperation::VECTOR_BW);
+    PeerValueMatrix<double> bandwidthValuesWrite1(worldSize, worldSize, key + "_write1");
+    PeerValueMatrix<double> bandwidthValuesWrite2(worldSize, worldSize, key + "_write2");
+    PeerValueMatrix<double> bandwidthValuesTotal(worldSize, worldSize, key + "_total");
+
+    for (int srcDeviceId = 0; srcDeviceId < worldSize; srcDeviceId++) {
+        for (int peerDeviceId = 0; peerDeviceId < worldSize; peerDeviceId++) {
+            if (peerDeviceId == srcDeviceId) {
+                continue;
+            }
+
+            MultinodeDeviceBufferUnicast src1(size, srcDeviceId), src2(size, srcDeviceId);
+            MultinodeDeviceBufferUnicast peer1(size, peerDeviceId), peer2(size, peerDeviceId);
+
+            std::vector<const MemcpyBuffer*> srcNodes = {&src1, &peer2};
+            std::vector<const MemcpyBuffer*> peerNodes = {&peer1, &src2};
+
+            auto results = memcpyInstance.doMemcpyVector(srcNodes, peerNodes);
+            bandwidthValuesWrite1.value(srcDeviceId, peerDeviceId) = results[0];
+            bandwidthValuesWrite2.value(srcDeviceId, peerDeviceId) = results[1];
+            bandwidthValuesTotal.value(srcDeviceId, peerDeviceId) = results[0] + results[1];
+        }
+    }
+
+    output->addTestcaseResults(bandwidthValuesWrite1, "memcpy SM CPU(row) <-> GPU(column) Write1 bandwidth (GB/s)");
+    output->addTestcaseResults(bandwidthValuesWrite2, "memcpy SM CPU(row) <-> GPU(column) Write2 bandwidth (GB/s)");
+    output->addTestcaseResults(bandwidthValuesTotal, "memcpy SM CPU(row) <-> GPU(column) Total bandwidth (GB/s)");
+}
+
+void MultinodeAllToOneWriteSM::run(unsigned long long size, unsigned long long loopCount) {
+    PeerValueMatrix<double> bandwidthValues(1, worldSize, key);
+    MemcpyOperation memcpyInstance(loopCount, new MemcpyInitiatorSM(), new NodeHelperMulti(), PREFER_SRC_CONTEXT, MemcpyOperation::SUM_BW);
+
+    for (int dstDeviceId = 0; dstDeviceId < worldSize; dstDeviceId++) {
+        std::vector<const MemcpyBuffer*> srcNodes;
+        std::vector<const MemcpyBuffer*> dstNodes;
+
+        for (int srcDeviceId = 0; srcDeviceId < worldSize; srcDeviceId++) {
+            if (dstDeviceId == srcDeviceId) {
+                continue;
+            }
+
+            srcNodes.push_back(new MultinodeDeviceBufferLocal(size, srcDeviceId));
+            dstNodes.push_back(new MultinodeDeviceBufferUnicast(size, dstDeviceId));
+        }
+
+        bandwidthValues.value(0, dstDeviceId) = memcpyInstance.doMemcpy(srcNodes, dstNodes);
+
+        for (auto node : dstNodes) {
+            delete node;
+        }
+        for (auto node : srcNodes) {
+            delete node;
+        }
+    }
+
+    output->addTestcaseResults(bandwidthValues, "memcpy SM All Gpus -> GPU(column) total bandwidth (GB/s)");
+}
+
+void MultinodeAllFromOneReadSM::run(unsigned long long size, unsigned long long loopCount) {
+    PeerValueMatrix<double> bandwidthValues(1, worldSize, key);
+    MemcpyOperation memcpyInstance(loopCount, new MemcpyInitiatorSM(), new NodeHelperMulti(), PREFER_DST_CONTEXT, MemcpyOperation::SUM_BW);
+
+    for (int srcDeviceId = 0; srcDeviceId < worldSize; srcDeviceId++) {
+        std::vector<const MemcpyBuffer*> srcNodes;
+        std::vector<const MemcpyBuffer*> dstNodes;
+
+        for (int dstDeviceId = 0; dstDeviceId < worldSize; dstDeviceId++) {
+            if (dstDeviceId == srcDeviceId) {
+                continue;
+            }
+
+            srcNodes.push_back(new MultinodeDeviceBufferUnicast(size, srcDeviceId));
+            dstNodes.push_back(new MultinodeDeviceBufferLocal(size, dstDeviceId));
+        }
+
+        bandwidthValues.value(0, srcDeviceId) = memcpyInstance.doMemcpy(srcNodes, dstNodes);
+
+        for (auto node : dstNodes) {
+            delete node;
+        }
+        for (auto node : srcNodes) {
+            delete node;
+        }
+    }
+
+    output->addTestcaseResults(bandwidthValues, "memcpy SM All Gpus <- GPU(column) total bandwidth (GB/s)");
+}
+
+void MultinodeBroadcastOneToAllSM::run(unsigned long long size, unsigned long long loopCount) {
+    PeerValueMatrix<double> bandwidthValues(1, worldSize, key);
+    MemcpyOperation memcpyInstance(loopCount, new MemcpyInitiatorMulticastWrite(), new NodeHelperMulti(), PREFER_DST_CONTEXT, MemcpyOperation::SUM_BW);
+
+    for (int dstDeviceId = 0; dstDeviceId < worldSize; dstDeviceId++) {
+        std::vector<const MemcpyBuffer*> srcNodes;
+        std::vector<const MemcpyBuffer*> dstNodes;
+
+        srcNodes.push_back(new MultinodeDeviceBufferLocal(size, dstDeviceId));
+        dstNodes.push_back(new MultinodeDeviceBufferMulticast(size, dstDeviceId));
+
+        bandwidthValues.value(0, dstDeviceId) = memcpyInstance.doMemcpy(srcNodes, dstNodes);
+
+        for (auto node : dstNodes) {
+            delete node;
+        }
+        for (auto node : srcNodes) {
+            delete node;
+        }
+    }
+
+    output->addTestcaseResults(bandwidthValues, "multicast SM GPU(column) -> All Gpus total bandwidth (GB/s)");
+}
+
+void MultinodeBroadcastAllToAllSM::run(unsigned long long size, unsigned long long loopCount) {
+    PeerValueMatrix<double> bandwidthValues(1, 1, key);
+    MemcpyOperation memcpyInstance(loopCount, new MemcpyInitiatorMulticastWrite(), new NodeHelperMulti(), PREFER_DST_CONTEXT, MemcpyOperation::SUM_BW);
+    std::vector<const MemcpyBuffer*> srcNodes;
+    std::vector<const MemcpyBuffer*> dstNodes;
+
+    for (int dstDeviceId = 0; dstDeviceId < worldSize; dstDeviceId++) {
+        srcNodes.push_back(new MultinodeDeviceBufferLocal(size, dstDeviceId));
+        dstNodes.push_back(new MultinodeDeviceBufferMulticast(size, dstDeviceId));
+    }
+
+    bandwidthValues.value(0, 0) = memcpyInstance.doMemcpy(srcNodes, dstNodes);
+
+    for (auto node : dstNodes) {
+        delete node;
+    }
+    for (auto node : srcNodes) {
+        delete node;
+    }
+
+    output->addTestcaseResults(bandwidthValues, "multicast SM All -> All Gpus total bandwidth (GB/s)");
+}
+
+void MultinodeBisectWriteCE::run(unsigned long long size, unsigned long long loopCount) {
+    PeerValueMatrix<double> bandwidthValues(worldSize, 1, key);
+    MemcpyOperation memcpyInstance(loopCount, new MemcpyInitiatorCE(), new NodeHelperMulti(), PREFER_SRC_CONTEXT, MemcpyOperation::VECTOR_BW);
+    std::vector<std::string> rowLabels;
+    std::vector<const MemcpyBuffer*> srcNodes, dstNodes;
+
+    for (int i = 0; i < worldSize; i++) {
+        int peer = (i + worldSize / 2) % worldSize;
+        srcNodes.push_back(new MultinodeDeviceBufferUnicast(size, i));
+        dstNodes.push_back(new MultinodeDeviceBufferUnicast(size, peer));
+
+        std::stringstream s;
+        s << getPaddedProcessId(i) << "->" << getPaddedProcessId(peer);
+        rowLabels.push_back(s.str());
+    }
+
+    auto results = memcpyInstance.doMemcpyVector(dstNodes, srcNodes);
+
+    for (int i = 0; i < results.size(); i++) {
+        bandwidthValues.value(i, 0) = results[i];
+    }
+    bandwidthValues.setRowLabels(rowLabels);
+
+    for (auto node : dstNodes) {
+        delete node;
+    }
+    for (auto node : srcNodes) {
+        delete node;
+    }
+
+    output->addTestcaseResults(bandwidthValues, "Bisect benchmarking, simultaneous write CE BW");
+}
+
+#endif

--- a/output.h
+++ b/output.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef OUTPUT_H
-#define OUTPUT_H
+#ifndef OUTPUT_H_
+#define OUTPUT_H_
 
 #include <string>
 #include <vector>
@@ -44,9 +44,8 @@ extern const std::string NVB_WAIVED;
 extern const std::string NVB_NOT_FOUND;
 extern const std::string NVB_ERROR_STATUS;
 
-class Output
-{
-public:
+class Output {
+ public:
     virtual void addTestcase(const std::string &name, const std::string &status, const std::string &msg = "");
 
     /*
@@ -60,9 +59,9 @@ public:
     virtual void setTestcaseStatusAndAddIfNeeded(const std::string &name, const std::string &status, const std::string &msg = "");
 
     virtual void print();
-    
+
     /*
-     * Records a global error 
+     * Records a global error
      *
      * @param errorParts - each entry in this vector is one line of an error. In JSON output, all lines are combined.
      */
@@ -74,7 +73,7 @@ public:
     virtual void recordError(const std::string &error);
 
     /*
-     * Records a test error 
+     * Records a test error
      *
      * @param errorPart1 - the first part of the error. For plain text output, this is printed on line 1.
      * @param errorPart2 - the second part of the error. For plain text output, this is printed on line 2.
@@ -98,4 +97,5 @@ public:
 };
 
 extern Output *output;
-#endif
+
+#endif  // OUTPUT_H_

--- a/testcase.h
+++ b/testcase.h
@@ -15,19 +15,24 @@
  * limitations under the License.
  */
 
-#ifndef BENCHMARK_H
-#define BENCHMARK_H
+#ifndef TESTCASE_H_
+#define TESTCASE_H_
+
 
 #include "common.h"
 #include "inline_common.h"
 #include "memcpy.h"
 
 class Testcase {
-protected:
+ protected:
     std::string key;
     std::string desc;
 
     static bool filterHasAccessiblePeerPairs();
+    static bool filterSupportsMulticast();
+#ifdef MULTINODE
+    static bool filterHasMultipleGPUsMultinode();
+#endif
 
     // helper functions
     void allToOneHelper(unsigned long long size, MemcpyOperation &memcpyInstance, PeerValueMatrix<double> &bandwidthValues, bool isRead);
@@ -36,7 +41,7 @@ protected:
     void allHostBidirHelper(unsigned long long size, MemcpyOperation &memcpyInstance, PeerValueMatrix<double> &bandwidthValues, bool sourceIsHost);
     void latencyHelper(const MemcpyBuffer &dataBuffer, bool measureDeviceToDeviceLatency);
 
-public:
+ public:
     Testcase(std::string key, std::string desc);
     virtual ~Testcase() {}
 
@@ -55,7 +60,7 @@ public:
 
 // Host to device CE memcpy using cuMemcpyAsync
 class HostToDeviceCE: public Testcase {
-public:
+ public:
     HostToDeviceCE() : Testcase("host_to_device_memcpy_ce",
             "\tHost to device CE memcpy using cuMemcpyAsync") {}
     virtual ~HostToDeviceCE() {}
@@ -64,8 +69,8 @@ public:
 
 // Device to host CE memcpy using cuMemcpyAsync
 class DeviceToHostCE: public Testcase {
-public:
-    DeviceToHostCE() : Testcase("device_to_host_memcpy_ce", 
+ public:
+    DeviceToHostCE() : Testcase("device_to_host_memcpy_ce",
             "\tDevice to host CE memcpy using cuMemcpyAsync") {}
     virtual ~DeviceToHostCE() {}
     void run(unsigned long long size, unsigned long long loopCount);
@@ -73,7 +78,7 @@ public:
 
 // Host to device bidirectional CE memcpy using cuMemcpyAsync
 class HostToDeviceBidirCE: public Testcase {
-public:
+ public:
     HostToDeviceBidirCE() : Testcase("host_to_device_bidirectional_memcpy_ce",
             "\tA host to device copy is measured while a device to host copy is run simultaneously.\n"
             "\tOnly the host to device copy bandwidth is reported.") {}
@@ -83,7 +88,7 @@ public:
 
 // Device to host bidirectional CE memcpy using cuMemcpyAsync
 class DeviceToHostBidirCE: public Testcase {
-public:
+ public:
     DeviceToHostBidirCE() : Testcase("device_to_host_bidirectional_memcpy_ce",
             "\tA device to host copy is measured while a host to device copy is run simultaneously.\n"
             "\tOnly the device to host copy bandwidth is reported.") {}
@@ -93,7 +98,7 @@ public:
 
 // Host to device bidirectional SM memcpy
 class HostToDeviceBidirSM: public Testcase {
-public:
+ public:
     HostToDeviceBidirSM() : Testcase("host_to_device_bidirectional_memcpy_sm",
             "\tA host to device copy is measured while a device to host copy is run simultaneously.\n"
             "\tOnly the host to device copy bandwidth is reported.") {}
@@ -103,7 +108,7 @@ public:
 
 // Device to host bidirectional SM memcpy
 class DeviceToHostBidirSM: public Testcase {
-public:
+ public:
     DeviceToHostBidirSM() : Testcase("device_to_host_bidirectional_memcpy_sm",
             "\tA device to host copy is measured while a host to device copy is run simultaneously.\n"
             "\tOnly the device to host copy bandwidth is reported.") {}
@@ -113,7 +118,7 @@ public:
 
 // Device to Device CE Read memcpy using cuMemcpyAsync
 class DeviceToDeviceReadCE: public Testcase {
-public:
+ public:
     DeviceToDeviceReadCE() : Testcase("device_to_device_memcpy_read_ce",
             "\tMeasures bandwidth of cuMemcpyAsync between each pair of accessible peers.\n"
             "\tRead tests launch a copy from the peer device to the target using the target's context.") {}
@@ -124,7 +129,7 @@ public:
 
 // Device to Device CE Write memcpy using cuMemcpyAsync
 class DeviceToDeviceWriteCE: public Testcase {
-public:
+ public:
     DeviceToDeviceWriteCE() : Testcase("device_to_device_memcpy_write_ce",
             "\tMeasures bandwidth of cuMemcpyAsync between each pair of accessible peers.\n"
             "\tWrite tests launch a copy from the target device to the peer using the target's context.") {}
@@ -135,8 +140,8 @@ public:
 
 // Device to Device Bidirectional Read CE memcpy using cuMemcpyAsync
 class DeviceToDeviceBidirReadCE: public Testcase {
-public:
-    DeviceToDeviceBidirReadCE() : Testcase("device_to_device_bidirectional_memcpy_read_ce", 
+ public:
+    DeviceToDeviceBidirReadCE() : Testcase("device_to_device_bidirectional_memcpy_read_ce",
             "\tMeasures bandwidth of cuMemcpyAsync between each pair of accessible peers.\n"
             "\tA copy in the opposite direction of the measured copy is run simultaneously but not measured.\n"
             "\tRead tests launch a copy from the peer device to the target using the target's context.") {}
@@ -147,8 +152,8 @@ public:
 
 // Device to Device Bidirectional Write CE memcpy using cuMemcpyAsync
 class DeviceToDeviceBidirWriteCE: public Testcase {
-public:
-    DeviceToDeviceBidirWriteCE() : Testcase("device_to_device_bidirectional_memcpy_write_ce", 
+ public:
+    DeviceToDeviceBidirWriteCE() : Testcase("device_to_device_bidirectional_memcpy_write_ce",
             "\tMeasures bandwidth of cuMemcpyAsync between each pair of accessible peers.\n"
             "\tA copy in the opposite direction of the measured copy is run simultaneously but not measured.\n"
             "\tWrite tests launch a copy from the target device to the peer using the target's context.") {}
@@ -157,10 +162,19 @@ public:
     bool filter() { return Testcase::filterHasAccessiblePeerPairs(); }
 };
 
+// Device local memcpy using cuMemcpyAsync
+class DeviceLocalCopy: public Testcase {
+ public:
+    DeviceLocalCopy() : Testcase("device_local_copy",
+            "\tMeasures bandwidth of cuMemcpyAsync between device buffers local to the GPU.\n") {}
+    virtual ~DeviceLocalCopy() {}
+    void run(unsigned long long size, unsigned long long loopCount);
+};
+
 // All to Host CE memcpy using cuMemcpyAsync
 class AllToHostCE: public Testcase {
-public:
-    AllToHostCE() : Testcase("all_to_host_memcpy_ce", 
+ public:
+    AllToHostCE() : Testcase("all_to_host_memcpy_ce",
             "\tMeasures bandwidth of cuMemcpyAsync between a single device and the host while simultaneously\n"
             "\trunning copies from all other devices to the host.") {}
     virtual ~AllToHostCE() {}
@@ -169,7 +183,7 @@ public:
 
 // All to Host bidirectional CE memcpy using cuMemcpyAsync
 class AllToHostBidirCE: public Testcase {
-public:
+ public:
     AllToHostBidirCE() : Testcase("all_to_host_bidirectional_memcpy_ce",
             "\tA device to host copy is measured while a host to device copy is run simultaneously.\n"
             "\tOnly the device to host copy bandwidth is reported.\n"
@@ -180,8 +194,8 @@ public:
 
 // Host to All CE memcpy using cuMemcpyAsync
 class HostToAllCE: public Testcase {
-public:
-    HostToAllCE() : Testcase("host_to_all_memcpy_ce", 
+ public:
+    HostToAllCE() : Testcase("host_to_all_memcpy_ce",
             "\tMeasures bandwidth of cuMemcpyAsync between the host to a single device while simultaneously\n"
             "\trunning copies from the host to all other devices.") {}
     virtual ~HostToAllCE() {}
@@ -190,7 +204,7 @@ public:
 
 // Host to All bidirectional CE memcpy using cuMemcpyAsync
 class HostToAllBidirCE: public Testcase {
-public:
+ public:
     HostToAllBidirCE() : Testcase("host_to_all_bidirectional_memcpy_ce",
             "\tA host to device copy is measured while a device to host copy is run simultaneously.\n"
             "\tOnly the host to device copy bandwidth is reported.\n"
@@ -202,8 +216,8 @@ public:
 
 // All to One CE Write memcpy using cuMemcpyAsync
 class AllToOneWriteCE: public Testcase {
-public:
-    AllToOneWriteCE() : Testcase("all_to_one_write_ce", 
+ public:
+    AllToOneWriteCE() : Testcase("all_to_one_write_ce",
             "\tMeasures the total bandwidth of copies from all accessible peers to a single device, for each\n"
             "\tdevice. Bandwidth is reported as the total inbound bandwidth for each device.\n"
             "\tWrite tests launch a copy from the target device to the peer using the target's context.") {}
@@ -214,8 +228,8 @@ public:
 
 // All to One CE Read memcpy using cuMemcpyAsync
 class AllToOneReadCE: public Testcase {
-public:
-    AllToOneReadCE() : Testcase("all_to_one_read_ce", 
+ public:
+    AllToOneReadCE() : Testcase("all_to_one_read_ce",
             "\tMeasures the total bandwidth of copies from all accessible peers to a single device, for each\n"
             "\tdevice. Bandwidth is reported as the total outbound bandwidth for each device.\n"
             "\tRead tests launch a copy from the peer device to the target using the target's context.") {}
@@ -226,7 +240,7 @@ public:
 
 // One to All CE Write memcpy using cuMemcpyAsync
 class OneToAllWriteCE: public Testcase {
-public:
+ public:
     OneToAllWriteCE() : Testcase("one_to_all_write_ce",
             "\tMeasures the total bandwidth of copies from a single device to all accessible peers, for each\n"
             "\tdevice. Bandwidth is reported as the total outbound bandwidth for each device.\n"
@@ -238,7 +252,7 @@ public:
 
 // One to All CE Read memcpy using cuMemcpyAsync
 class OneToAllReadCE: public Testcase {
-public:
+ public:
     OneToAllReadCE() : Testcase("one_to_all_read_ce",
             "\tMeasures the total bandwidth of copies from a single device to all accessible peers, for each\n"
             "\tdevice. Bandwidth is reported as the total inbound bandwidth for each device.\n"
@@ -251,17 +265,18 @@ public:
 // SM Testcase classes
 // Host to device SM latency using a ptr chase kernel
 class HostDeviceLatencySM: public Testcase {
-public:
-    HostDeviceLatencySM() : Testcase("host_device_latency_sm", 
-            "\tHost - device SM copy latency using a ptr chase kernel") {}
+ public:
+    HostDeviceLatencySM() : Testcase("host_device_latency_sm",
+            "\tHost - device access latency using a pointer chase kernel\n"
+            "\tA 2MB buffer is allocated on the host and is accessed by the GPU") {}
     virtual ~HostDeviceLatencySM() {}
     void run(unsigned long long size, unsigned long long loopCount);
 };
 
 // Host to device SM memcpy using a copy kernel
 class HostToDeviceSM: public Testcase {
-public:
-    HostToDeviceSM() : Testcase("host_to_device_memcpy_sm", 
+ public:
+    HostToDeviceSM() : Testcase("host_to_device_memcpy_sm",
             "\tHost to device SM memcpy using a copy kernel") {}
     virtual ~HostToDeviceSM() {}
     void run(unsigned long long size, unsigned long long loopCount);
@@ -269,8 +284,8 @@ public:
 
 // Device to host SM memcpy using a copy kernel
 class DeviceToHostSM: public Testcase {
-public:
-    DeviceToHostSM() : Testcase("device_to_host_memcpy_sm", 
+ public:
+    DeviceToHostSM() : Testcase("device_to_host_memcpy_sm",
             "\tDevice to host SM memcpy using a copy kernel") {}
     virtual ~DeviceToHostSM() {}
     void run(unsigned long long size, unsigned long long loopCount);
@@ -278,7 +293,7 @@ public:
 
 // Device to Device SM Read memcpy using a copy kernel
 class DeviceToDeviceReadSM: public Testcase {
-public:
+ public:
     DeviceToDeviceReadSM() : Testcase("device_to_device_memcpy_read_sm",
             "\tMeasures bandwidth of a copy kernel between each pair of accessible peers.\n"
             "\tRead tests launch a copy from the peer device to the target using the target's context.") {}
@@ -289,10 +304,11 @@ public:
 
 // Device to Device SM Latency ptr chase kernel
 class DeviceToDeviceLatencySM: public Testcase {
-public:
+ public:
     DeviceToDeviceLatencySM() : Testcase("device_to_device_latency_sm",
             "\tMeasures latency of a pointer derefernce operation between each pair of accessible peers.\n"
-            "\tMemory is allocated on a GPU and is accessed by the peer GPU to determine latency.") {}
+            "\tA 2MB buffer is allocated on a GPU and is accessed by the peer GPU to determine latency.\n"
+            "\t--bufferSize flag is ignored") {}
     virtual ~DeviceToDeviceLatencySM() {}
     void run(unsigned long long size, unsigned long long loopCount);
     bool filter() { return Testcase::filterHasAccessiblePeerPairs(); }
@@ -300,7 +316,7 @@ public:
 
 // Device to Device SM Write memcpy using a copy kernel
 class DeviceToDeviceWriteSM: public Testcase {
-public:
+ public:
     DeviceToDeviceWriteSM() : Testcase("device_to_device_memcpy_write_sm",
             "\tMeasures bandwidth of a copy kernel between each pair of accessible peers.\n"
             "\tWrite tests launch a copy from the target device to the peer using the target's context.") {}
@@ -311,7 +327,7 @@ public:
 
 // Device to Device bidirectional SM Read memcpy using a copy kernel
 class DeviceToDeviceBidirReadSM: public Testcase {
-public:
+ public:
     DeviceToDeviceBidirReadSM() : Testcase("device_to_device_bidirectional_memcpy_read_sm",
             "\tMeasures bandwidth of a copy kernel between each pair of accessible peers. Copies are run\n"
             "\tin both directions between each pair, and the sum is reported.\n"
@@ -323,7 +339,7 @@ public:
 
 // Device to Device bidirectional SM Write memcpy using a copy kernel
 class DeviceToDeviceBidirWriteSM: public Testcase {
-public:
+ public:
     DeviceToDeviceBidirWriteSM() : Testcase("device_to_device_bidirectional_memcpy_write_sm",
             "\tMeasures bandwidth of a copy kernel between each pair of accessible peers. Copies are run\n"
             "\tin both directions between each pair, and the sum is reported.\n"
@@ -335,8 +351,8 @@ public:
 
 // All to Host SM memcpy using a copy kernel
 class AllToHostSM: public Testcase {
-public:
-    AllToHostSM() : Testcase("all_to_host_memcpy_sm", 
+ public:
+    AllToHostSM() : Testcase("all_to_host_memcpy_sm",
             "\tMeasures bandwidth of a copy kernel between a single device and the host while simultaneously\n"
             "\trunning copies from all other devices to the host.") {}
     virtual ~AllToHostSM() {}
@@ -345,7 +361,7 @@ public:
 
 // All to Host bidirectional SM memcpy using a copy kernel
 class AllToHostBidirSM: public Testcase {
-public:
+ public:
     AllToHostBidirSM() : Testcase("all_to_host_bidirectional_memcpy_sm",
             "\tA device to host bandwidth of a copy kernel is measured while a host to device copy is run simultaneously.\n"
             "\tOnly the device to host copy bandwidth is reported.\n"
@@ -356,8 +372,8 @@ public:
 
 // Host to All SM memcpy using a copy kernel
 class HostToAllSM: public Testcase {
-public:
-    HostToAllSM() : Testcase("host_to_all_memcpy_sm", 
+ public:
+    HostToAllSM() : Testcase("host_to_all_memcpy_sm",
             "\tMeasures bandwidth of a copy kernel between the host to a single device while simultaneously\n"
             "\trunning copies from the host to all other devices.") {}
     virtual ~HostToAllSM() {}
@@ -366,7 +382,7 @@ public:
 
 // Host to All bidirectional SM memcpy using a copy kernel
 class HostToAllBidirSM: public Testcase {
-public:
+ public:
     HostToAllBidirSM() : Testcase("host_to_all_bidirectional_memcpy_sm",
             "\tA host to device bandwidth of a copy kernel is measured while a device to host copy is run simultaneously.\n"
             "\tOnly the host to device copy bandwidth is reported.\n"
@@ -377,7 +393,7 @@ public:
 
 // All to One SM Write memcpy using a copy kernel
 class AllToOneWriteSM: public Testcase {
-public:
+ public:
     AllToOneWriteSM() : Testcase("all_to_one_write_sm",
             "\tMeasures the total bandwidth of copies from all accessible peers to a single device, for each\n"
             "\tdevice. Bandwidth is reported as the total inbound bandwidth for each device.\n"
@@ -389,8 +405,8 @@ public:
 
 // All to One SM Read memcpy using a copy kernel
 class AllToOneReadSM: public Testcase {
-public:
-    AllToOneReadSM() : Testcase("all_to_one_read_sm", 
+ public:
+    AllToOneReadSM() : Testcase("all_to_one_read_sm",
             "\tMeasures the total bandwidth of copies from all accessible peers to a single device, for each\n"
             "\tdevice. Bandwidth is reported as the total outbound bandwidth for each device.\n"
             "\tRead tests launch a copy from the peer device to the target using the target's context.") {}
@@ -401,8 +417,8 @@ public:
 
 // One to All SM Write memcpy using a copy kernel
 class OneToAllWriteSM: public Testcase {
-public:
-    OneToAllWriteSM() : Testcase("one_to_all_write_sm", 
+ public:
+    OneToAllWriteSM() : Testcase("one_to_all_write_sm",
             "\tMeasures the total bandwidth of copies from a single device to all accessible peers, for each\n"
             "\tdevice. Bandwidth is reported as the total outbound bandwidth for each device.\n"
             "\tWrite tests launch a copy from the target device to the peer using the target's context.") {}
@@ -413,8 +429,8 @@ public:
 
 // One to All SM Read memcpy using a copy kernel
 class OneToAllReadSM: public Testcase {
-public:
-    OneToAllReadSM() : Testcase("one_to_all_read_sm", 
+ public:
+    OneToAllReadSM() : Testcase("one_to_all_read_sm",
             "\tMeasures the total bandwidth of copies from a single device to all accessible peers, for each\n"
             "\tdevice. Bandwidth is reported as the total inbound bandwidth for each device.\n"
             "\tRead tests launch a copy from the peer device to the target using the target's context.") {}
@@ -423,4 +439,155 @@ public:
     bool filter() { return Testcase::filterHasAccessiblePeerPairs(); }
 };
 
+#ifdef MULTINODE
+// Device to Device CE Read memcpy using cuMemcpyAsync
+class MultinodeDeviceToDeviceReadCE: public Testcase {
+ public:
+    MultinodeDeviceToDeviceReadCE() : Testcase("multinode_device_to_device_memcpy_read_ce",
+            "\tMeasures bandwidth of cuMemcpyAsync between each pair of accessible peers.\n"
+            "\tRead tests launch a copy from the peer device to the target using the target's context.") {}
+    virtual ~MultinodeDeviceToDeviceReadCE() {}
+    void run(unsigned long long size, unsigned long long loopCount);
+    bool filter() { return Testcase::filterHasMultipleGPUsMultinode(); }
+};
+
+// Device to Device CE Write memcpy using cuMemcpyAsync
+class MultinodeDeviceToDeviceWriteCE: public Testcase {
+ public:
+    MultinodeDeviceToDeviceWriteCE() : Testcase("multinode_device_to_device_memcpy_write_ce",
+            "\tMeasures bandwidth of cuMemcpyAsync between each pair of accessible peers.\n"
+            "\tWrite tests launch a copy from the target device to the peer using the target's context.") {}
+    virtual ~MultinodeDeviceToDeviceWriteCE() {}
+    void run(unsigned long long size, unsigned long long loopCount);
+    bool filter() { return Testcase::filterHasMultipleGPUsMultinode(); }
+};
+
+// Device to Device Bidirectional Read CE memcpy using cuMemcpyAsync
+class MultinodeDeviceToDeviceBidirReadCE: public Testcase {
+ public:
+    MultinodeDeviceToDeviceBidirReadCE() : Testcase("multinode_device_to_device_bidirectional_memcpy_read_ce",
+            "\tMeasures bandwidth of cuMemcpyAsync between each pair of accessible peers.\n"
+            "\tA copy in the opposite direction of the measured copy is run simultaneously but not measured.\n"
+            "\tRead tests launch a copy from the peer device to the target using the target's context.") {}
+    virtual ~MultinodeDeviceToDeviceBidirReadCE() {}
+    void run(unsigned long long size, unsigned long long loopCount);
+    bool filter() { return Testcase::filterHasMultipleGPUsMultinode(); }
+};
+
+// Device to Device Bidirectional Write CE memcpy using cuMemcpyAsync
+class MultinodeDeviceToDeviceBidirWriteCE: public Testcase {
+ public:
+    MultinodeDeviceToDeviceBidirWriteCE() : Testcase("multinode_device_to_device_bidirectional_memcpy_write_ce",
+            "\tMeasures bandwidth of cuMemcpyAsync between each pair of accessible peers.\n"
+            "\tA copy in the opposite direction of the measured copy is run simultaneously but not measured.\n"
+            "\tWrite tests launch a copy from the target device to the peer using the target's context.") {}
+    virtual ~MultinodeDeviceToDeviceBidirWriteCE() {}
+    void run(unsigned long long size, unsigned long long loopCount);
+    bool filter() { return Testcase::filterHasMultipleGPUsMultinode(); }
+};
+
+// Device to Device SM Read memcpy using a copy kernel
+class MultinodeDeviceToDeviceReadSM: public Testcase {
+ public:
+    MultinodeDeviceToDeviceReadSM() : Testcase("multinode_device_to_device_memcpy_read_sm",
+            "\tMeasures bandwidth of a copy kernel between each pair of accessible peers.\n"
+            "\tRead tests launch a copy from the peer device to the target using the target's context.") {}
+    virtual ~MultinodeDeviceToDeviceReadSM() {}
+    void run(unsigned long long size, unsigned long long loopCount);
+    bool filter() { return Testcase::filterHasMultipleGPUsMultinode(); }
+};
+
+// Device to Device SM Write memcpy using a copy kernel
+class MultinodeDeviceToDeviceWriteSM: public Testcase {
+ public:
+    MultinodeDeviceToDeviceWriteSM() : Testcase("multinode_device_to_device_memcpy_write_sm",
+            "\tMeasures bandwidth of a copy kernel between each pair of accessible peers.\n"
+            "\tWrite tests launch a copy from the target device to the peer using the target's context.") {}
+    virtual ~MultinodeDeviceToDeviceWriteSM() {}
+    void run(unsigned long long size, unsigned long long loopCount);
+    bool filter() { return Testcase::filterHasMultipleGPUsMultinode(); }
+};
+
+// Device to Device bidirectional SM Read memcpy using a copy kernel
+class MultinodeDeviceToDeviceBidirReadSM: public Testcase {
+ public:
+    MultinodeDeviceToDeviceBidirReadSM() : Testcase("multinode_device_to_device_bidirectional_memcpy_read_sm",
+            "\tMeasures bandwidth of a copy kernel between each pair of accessible peers. Copies are run\n"
+            "\tin both directions between each pair, and the sum is reported.\n"
+            "\tRead tests launch a copy from the peer device to the target using the target's context.") {}
+    virtual ~MultinodeDeviceToDeviceBidirReadSM() {}
+    void run(unsigned long long size, unsigned long long loopCount);
+    bool filter() { return Testcase::filterHasMultipleGPUsMultinode(); }
+};
+
+// Device to Device bidirectional SM Write memcpy using a copy kernel
+class MultinodeDeviceToDeviceBidirWriteSM: public Testcase {
+ public:
+    MultinodeDeviceToDeviceBidirWriteSM() : Testcase("multinode_device_to_device_bidirectional_memcpy_write_sm",
+            "\tMeasures bandwidth of a copy kernel between each pair of accessible peers. Copies are run\n"
+            "\tin both directions between each pair, and the sum is reported.\n"
+            "\tWrite tests launch a copy from the target device to the peer using the target's context.") {}
+    virtual ~MultinodeDeviceToDeviceBidirWriteSM() {}
+    void run(unsigned long long size, unsigned long long loopCount);
+    bool filter() { return Testcase::filterHasMultipleGPUsMultinode(); }
+};
+
+class MultinodeAllToOneWriteSM: public Testcase {
+ public:
+    MultinodeAllToOneWriteSM() : Testcase("multinode_device_to_device_all_to_one_write_sm",
+            "\tMeasures the total bandwidth of copies from all accessible peers to a single device, for each\n"
+            "\tdevice. Bandwidth is reported as the total inbound bandwidth for each device.\n"
+            "\tWrite tests launch a copy from the peer to the target device using the peer's context.") {}
+    virtual ~MultinodeAllToOneWriteSM() {}
+    void run(unsigned long long size, unsigned long long loopCount);
+    bool filter() { return Testcase::filterHasMultipleGPUsMultinode(); }
+};
+
+class MultinodeAllFromOneReadSM: public Testcase {
+ public:
+    MultinodeAllFromOneReadSM() : Testcase("multinode_device_to_device_all_from_one_read_sm",
+            "\tMeasures the total bandwidth of copies from a single device to all accessible peers, for each\n"
+            "\tdevice. Bandwidth is reported as the total outbound bandwidth for each device.\n"
+            "\tRead tests launch a copy from the target device to the peer using the peer's context.") {}
+    virtual ~MultinodeAllFromOneReadSM() {}
+    void run(unsigned long long size, unsigned long long loopCount);
+    bool filter() { return Testcase::filterHasMultipleGPUsMultinode(); }
+};
+
+class MultinodeBroadcastOneToAllSM: public Testcase {
+ public:
+    MultinodeBroadcastOneToAllSM() : Testcase("multinode_device_to_device_broadcast_one_to_all_sm",
+            "\tMeasures bandwidth of a copy kernel copying data from device memory to multicast allocated memory\n"
+            "\tthat's mapped on all accessible peers.\n"
+            "\tTests launch a copy from the target device to the multicast memory on target using the target's context.") {}
+    virtual ~MultinodeBroadcastOneToAllSM() {}
+    void run(unsigned long long size, unsigned long long loopCount);
+    bool filter() { return Testcase::filterHasMultipleGPUsMultinode() && Testcase::filterSupportsMulticast(); }
+};
+
+class MultinodeBroadcastAllToAllSM: public Testcase {
+ public:
+    MultinodeBroadcastAllToAllSM() : Testcase("multinode_device_to_device_broadcast_all_to_all_sm",
+            "\tMeasures bandwidth of a copy kernels copying data from device memory to multicast allocated memory\n"
+            "\tthat's mapped on all accessible peers."
+            "\tAll devices are doing copies at the same time.\n"
+            "\tTests launch copies from the target device to the multicast memory on target using the target's context.") {}
+    virtual ~MultinodeBroadcastAllToAllSM() {}
+    void run(unsigned long long size, unsigned long long loopCount);
+    bool filter() { return Testcase::filterHasMultipleGPUsMultinode() && Testcase::filterSupportsMulticast(); }
+};
+
+// TODO(pgumienny) - add remaining combination of Read/Write CE/SM once the tooling is in
+class MultinodeBisectWriteCE: public Testcase {
+ public:
+    MultinodeBisectWriteCE() : Testcase("multinode_bisect_write_ce",
+            "\tMeasures bandwidths of simultaneous copies.\n"
+            "\tFor N GPU system there will be N copies occuring at the same time\n"
+            "\tGPU owned by rank A will be writing to GPU owned by rank (A + N/2) % N).") {}
+    virtual ~MultinodeBisectWriteCE() {}
+    void run(unsigned long long size, unsigned long long loopCount);
+    bool filter() { return Testcase::filterHasMultipleGPUsMultinode(); }
+};
 #endif
+
+#endif  // TESTCASE_H_

--- a/testcases_ce.cpp
+++ b/testcases_ce.cpp
@@ -21,7 +21,6 @@
 #include "output.h"
 #include "testcase.h"
 #include "memcpy.h"
-#include "common.h"
 
 void HostToDeviceCE::run(unsigned long long size, unsigned long long loopCount) {
     PeerValueMatrix<double> bandwidthValues(1, deviceCount, key);
@@ -210,6 +209,20 @@ void DeviceToDeviceBidirWriteCE::run(unsigned long long size, unsigned long long
     output->addTestcaseResults(bandwidthValuesWrite1, "memcpy CE GPU(row) <-> GPU(column) Write1 bandwidth (GB/s)");
     output->addTestcaseResults(bandwidthValuesWrite2, "memcpy CE GPU(row) <-> GPU(column) Write2 bandwidth (GB/s)");
     output->addTestcaseResults(bandwidthValuesTotal, "memcpy CE GPU(row) <-> GPU(column) Total bandwidth (GB/s)");
+}
+
+void DeviceLocalCopy::run(unsigned long long size, unsigned long long loopCount) {
+    PeerValueMatrix<double> bandwidthValues(1, deviceCount, key);
+    MemcpyOperation memcpyInstance(loopCount, new MemcpyInitiatorCE());
+
+    for (int deviceId = 0; deviceId < deviceCount; deviceId++) {
+        DeviceBuffer deviceBuffer1(size, deviceId);
+        DeviceBuffer deviceBuffer2(size, deviceId);
+
+        bandwidthValues.value(0, deviceId) = memcpyInstance.doMemcpy(deviceBuffer2, deviceBuffer1);
+    }
+
+    output->addTestcaseResults(bandwidthValues, "memcpy local GPU(column) bandwidth (GB/s)");
 }
 
 void AllToHostCE::run(unsigned long long size, unsigned long long loopCount) {

--- a/version.h
+++ b/version.h
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-#ifndef VERSION_H
-#define VERSION_H
+#ifndef VERSION_H_
+#define VERSION_H_
 
-#define NVBANDWIDTH_VERSION "v0.6"
+#define NVBANDWIDTH_VERSION "v0.7"
 #ifndef GIT_VERSION
 #define GIT_VERSION "unknown"
 #endif
 
-#endif
+#endif  // VERSION_H_


### PR DESCRIPTION
Release Notes:
* Support measurements on multinode systems
* Add tests for intra-device memory copies
* Default memcpy buffer size increased to 512MB
* Improved stability of bidirectional bandwidth measurements
* General bug fixes